### PR TITLE
Fix usage instructions to use revision rather than tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,19 @@ Swift Homomorphic Encryption requires:
 > Swift Homomorphic Encryption relies on [SystemRandomNumberGenerator](https://developer.apple.com/documentation/swift/systemrandomnumbergenerator) as a cryptographically secure random number generator, which may have platform-dependent behavior.
 
 Swift Homomorphic Encryption is available as a Swift Package Manager package.
-To use Swift Homomorphic Encryption, add the following dependency in your `Package.swift`:
+To use Swift Homomorphic Encryption, choose a [tag](https://github.com/apple/swift-homomorphic-encryption/tags).
+Then, add the following dependency in your `Package.swift`, adding the commit hash associated with the tag.
 ```swift
-.package(url: "https://github.com/apple/swift-homomorphic-encryption", .upToNextMajor(from: "0.1.0")),
+.package(
+    url: "https://github.com/apple/swift-homomorphic-encryption",
+    revision: "git-commit-associated-with-the-tag"),
 ```
+
+> [!NOTE]
+> Due to the use of `unsafeFlags` in Swift Homomorphic Encryption, you shouldn't depend on a git tag, which could prevent tagged releases of downstream projects.
+> In particular, without the `cross-module-optimization` flag, performance degrades dramatically.
+> One workaround is to add `SwiftHomomorphicEncryption` as a submodule rather than a package dependency.
+
 To use the `HomomorphicEncryption` library, add
 ```swift
 .product(name: "HomomorphicEncryption", package: "swift-homomorphic-encryption"),

--- a/Sources/HomomorphicEncryption/HomomorphicEncryption.docc/UsingSwiftHomomorphicEncryption.md
+++ b/Sources/HomomorphicEncryption/HomomorphicEncryption.docc/UsingSwiftHomomorphicEncryption.md
@@ -11,10 +11,19 @@ Swift Homomorphic Encryption requires:
 > Note: Swift Homomorphic Encryption relies on [SystemRandomNumberGenerator](https://developer.apple.com/documentation/swift/systemrandomnumbergenerator) as a cryptographically secure random number generator, which may have platform-dependent behavior.
 
 Swift Homomorphic Encryption is available as a Swift Package Manager package.
-To use Swift Homomorphic Encryption, add the following dependency in your `Package.swift`:
+To use Swift Homomorphic Encryption, choose a [tag](https://github.com/apple/swift-homomorphic-encryption/tags).
+Then, add the following dependency in your `Package.swift`, adding the commit hash associated with the tag.
 ```swift
-.package(url: "https://github.com/apple/swift-homomorphic-encryption", .upToNextMajor(from: "0.1.0")),
+.package(
+    url: "https://github.com/apple/swift-homomorphic-encryption",
+    revision: "git-commit-associated-with-the-tag"),
 ```
+
+> Note:
+> Due to the use of `unsafeFlags` in Swift Homomorphic Encryption, you shouldn't depend on a git tag, which could prevent tagged releases of downstream projects.
+> In particular, without the `cross-module-optimization` flag, performance degrades dramatically.
+> One workaround is to add `SwiftHomomorphicEncryption` as a submodule rather than a package dependency.
+
 To use the `HomomorphicEncryption` library, add
 ```swift
 .product(name: "HomomorphicEncryption", package: "swift-homomorphic-encryption"),


### PR DESCRIPTION
This wokrs around an issue with using unsafe flags in a tagged release.