### PR TITLE
Make PirTestUtils.getTestTable faster

### DIFF
--- a/Tests/PrivateInformationRetrievalTests/CuckooTableTests.swift
+++ b/Tests/PrivateInformationRetrievalTests/CuckooTableTests.swift
@@ -80,9 +80,9 @@ class CuckooTableTests: XCTestCase {
         let cuckooTable = try CuckooTable(config: config, database: testDatabase, using: rng)
         let summary = CuckooTable.CuckooTableInformation(
             entryCount: 100,
-            bucketCount: 64,
-            emptyBucketCount: 4,
-            loadFactor: 0.645)
+            bucketCount: 80,
+            emptyBucketCount: 19,
+            loadFactor: 0.52)
         XCTAssertEqual(try cuckooTable.summarize(), summary)
     }
 

--- a/Tests/PrivateInformationRetrievalTests/KeywordPirTests.swift
+++ b/Tests/PrivateInformationRetrievalTests/KeywordPirTests.swift
@@ -260,7 +260,7 @@ class KeywordPirTests: XCTestCase {
                 let cuckooConfig = try CuckooTableConfig(
                     hashFunctionCount: 2,
                     maxEvictionCount: 100,
-                    maxSerializedBucketSize: valueSize * 4,
+                    maxSerializedBucketSize: HashBucket.serializedSize(singleValueSize: valueSize) * 4,
                     bucketCount: .allowExpansion(expansionFactor: 1.1, targetLoadFactor: 0.7))
                 let keywordConfig = try KeywordPirConfig(
                     dimensionCount: 2,
@@ -291,7 +291,7 @@ class KeywordPirTests: XCTestCase {
                 processed: processed)
             let client = KeywordPirClient<PirClient>(
                 keywordParameter: keywordConfig.parameter,
-                pirParameter: pirParameter,
+                pirParameter: processed.pirParameter,
                 context: testContext)
             let secretKey = try testContext.generateSecretKey()
             let evaluationKey = try client.generateEvaluationKey(using: secretKey)

--- a/Tests/PrivateInformationRetrievalTests/PirTestUtils.swift
+++ b/Tests/PrivateInformationRetrievalTests/PirTestUtils.swift
@@ -49,8 +49,10 @@ package enum PirTestUtils {
         return generateRandomData(size: size, using: &rng)
     }
 
-    static func generateRandomData(size: Int, using rng: inout some RandomNumberGenerator) -> [UInt8] {
-        (0..<size).map { _ in UInt8.random(in: 0...UInt8.max, using: &rng) }
+    static func generateRandomData(size: Int, using rng: inout some PseudoRandomNumberGenerator) -> [UInt8] {
+        var data = [UInt8](repeating: 0, count: size)
+        rng.fill(&data)
+        return data
     }
 
     static func getTestTable(rowCount: Int, valueSize: Int) -> [KeywordValuePair] {
@@ -61,17 +63,21 @@ package enum PirTestUtils {
     static func getTestTable(
         rowCount: Int,
         valueSize: Int,
-        using rng: inout some RandomNumberGenerator,
+        using rng: inout some PseudoRandomNumberGenerator,
         keywordSize: Int = 30) -> [KeywordValuePair]
     {
-        var rows = [KeywordValuePair]()
+        precondition(rowCount > 0)
+        var keywords: Set<KeywordValuePair.Keyword> = []
+        var rows: [KeywordValuePair] = []
+        rows.reserveCapacity(rowCount)
         repeat {
             let keyword = PirTestUtils.generateRandomData(size: keywordSize, using: &rng)
-            if !rows.contains(where: { existingPair in keyword == existingPair.keyword }) {
-                rows.append(KeywordValuePair(
-                    keyword: keyword,
-                    value: PirTestUtils.generateRandomData(size: valueSize, using: &rng)))
+            if keywords.contains(keyword) {
+                continue
             }
+            keywords.insert(keyword)
+            let value = PirTestUtils.generateRandomData(size: valueSize, using: &rng)
+            rows.append(KeywordValuePair(keyword: keyword, value: value))
         } while rows.count < rowCount
         return rows
     }


### PR DESCRIPTION
I noticed it was quite slow with 1000 rows.