### PR TITLE
Switch to Swift 5.10

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 // Remember to update CI if changing
 
@@ -19,6 +19,7 @@
 import PackageDescription
 
 let swiftSettings: [SwiftSetting] = [
+    .enableExperimentalFeature("StrictConcurrency"),
     .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release)),
 ]
 
@@ -177,6 +178,7 @@ package.targets += [
             "HomomorphicEncryption",
         ],
         path: "Benchmarks/PolyBenchmark",
+        swiftSettings: swiftSettings,
         plugins: [
             .plugin(name: "BenchmarkPlugin", package: "package-benchmark"),
         ]),
@@ -187,6 +189,7 @@ package.targets += [
             "HomomorphicEncryption",
         ],
         path: "Benchmarks/RlweBenchmark",
+        swiftSettings: swiftSettings,
         plugins: [
             .plugin(name: "BenchmarkPlugin", package: "package-benchmark"),
         ]),
@@ -200,6 +203,7 @@ package.targets += [
             "PrivateInformationRetrievalProtobuf",
         ],
         path: "Benchmarks/PrivateInformationRetrievalBenchmark",
+        swiftSettings: swiftSettings,
         plugins: [
             .plugin(name: "BenchmarkPlugin", package: "package-benchmark"),
         ]),

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The PIR implementation in Swift Homomorphic Encryption uses HE to improve upon t
 Swift Homomorphic Encryption requires:
 * 64-bit processor with little-endian memory representation
 * macOS or Linux operating system
-* [Swift](https://www.swift.org/) version 6.0 or later
+* [Swift](https://www.swift.org/) version 5.10 or later
 
 > [!NOTE]
 > Swift Homomorphic Encryption relies on [SystemRandomNumberGenerator](https://developer.apple.com/documentation/swift/systemrandomnumbergenerator) as a cryptographically secure random number generator, which may have platform-dependent behavior.
@@ -90,7 +90,7 @@ to your Swift code to access the functionality in the `HomomorphicEncryption` li
 ## Developing Swift Homomorphic Encryption
 ### Dependencies
 Building Swift Homomorphic Encryption requires:
-* [Swift](https://www.swift.org/) version 6.0 or later
+* [Swift](https://www.swift.org/) version 5.10 or later
 
 Additionally, developing Swift Homomorphic Encryption requires:
 * [Nick Lockwood swiftformat](https://github.com/nicklockwood/SwiftFormat), v0.54.0

--- a/Sources/HomomorphicEncryption/HomomorphicEncryption.docc/UsingSwiftHomomorphicEncryption.md
+++ b/Sources/HomomorphicEncryption/HomomorphicEncryption.docc/UsingSwiftHomomorphicEncryption.md
@@ -6,7 +6,7 @@ Get started using Swift Homomorphic Encryption.
 Swift Homomorphic Encryption requires:
 * 64-bit processor with little-endian memory representation
 * macOS or Linux operating system
-* [Swift](https://www.swift.org/) version 6.0 or later
+* [Swift](https://www.swift.org/) version 5.10 or later
 
 > Note: Swift Homomorphic Encryption relies on [SystemRandomNumberGenerator](https://developer.apple.com/documentation/swift/systemrandomnumbergenerator) as a cryptographically secure random number generator, which may have platform-dependent behavior.
 


### PR DESCRIPTION
No need to block using 5.10, while we are not explicitly using a Swift 6.0 feature.