### PR TITLE
Move DoubleWidth attribution from apple to swiftlang

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -202,7 +202,7 @@
 
 -------------------------------------------------------------------------
 
-This license applies to parts of Swift Homomorphic Encryption originating from the https://github.com/apple/swift/ repository:
+This license applies to parts of Swift Homomorphic Encryption originating from the https://github.com/swiftlang/swift/ repository:
 - Sources/HomomorphicEncryption/DoubleWidthUInt.swift
 - Tests/HomomorphicEncryptionTests/DoubleWidthUIntTests.swift
 

--- a/Sources/HomomorphicEncryption/DoubleWidthUInt.swift
+++ b/Sources/HomomorphicEncryption/DoubleWidthUInt.swift
@@ -21,7 +21,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // Taken from
-// https://github.com/apple/swift/blob/fc23eef2d2b2e42116ac94a6cc0d0d2cc96688f5/test/Prototypes/DoubleWidth.swift.gyb
+// https://github.com/swiftlang/swift/blob/fc23eef2d2b2e42116ac94a6cc0d0d2cc96688f5/test/Prototypes/DoubleWidth.swift.gyb
 // and modified with the following changes:
 // * Restrict `Base` to unsigned integers only.
 // * Rename `DoubleWidth` to `DoubleWidthUInt`.

--- a/Tests/HomomorphicEncryptionTests/DoubleWidthUIntTests.swift
+++ b/Tests/HomomorphicEncryptionTests/DoubleWidthUIntTests.swift
@@ -20,8 +20,8 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-//  Taken from
-//  https://github.com/apple/swift/blob/fc23eef2d2b2e42116ac94a6cc0d0d2cc96688f5/test/Prototypes/DoubleWidth.swift.gyb
+// Taken from
+// https://github.com/swiftlang/swift/blob/fc23eef2d2b2e42116ac94a6cc0d0d2cc96688f5/test/Prototypes/DoubleWidth.swift.gyb
 // and modified to accommodate changes to `DoubleWidthUInt.swift`.
 
 @testable import HomomorphicEncryption


### PR DESCRIPTION
Move DoubleWidth attribution from apple to swiftlang