### PR TITLE
Move swift-docc-plugin back to swiftlang

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1556ae0b547f8e688ae5876b1f21579f66ce8684e7ba120f9f71ec5cc9524064",
+  "originHash" : "5b9484bfe90fcad029a55247c3e4766943d22ed6cccd872ea90c25339e5c2352",
   "pins" : [
     {
       "identity" : "hdrhistogram-swift",
@@ -58,7 +58,7 @@
     {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-plugin",
+      "location" : "https://github.com/swiftlang/swift-docc-plugin",
       "state" : {
         "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
         "version" : "1.3.0"

--- a/Package.swift
+++ b/Package.swift
@@ -50,11 +50,10 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.4.0"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-numerics", from: "1.0.0"),
-        // Keep version in sync with README
-        .package(url: "https://github.com/apple/swift-protobuf", from: "1.27.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-numerics", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-protobuf", from: "1.27.0"), // Keep version in sync with README
+        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
https://github.com/apple/swift-homomorphic-encryption/pull/14/files accidentally reverted `https://github.com/swiftlang/swift-docc-plugin` to `https://github.com/apple/swift-docc-plugin`.
This PR reverts that change, and sorts the dependencies.