### PR TITLE
Update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ Applications of Swift Homomorphic Encryption include:
 ## Overview
 Swift Homomorphic Encryption is a collection of libraries and executables.
 For more information, refer to documentation for the libraries:
-* [HomomorphicEncryption](Sources/HomomorphicEncryption/HomomorphicEncryption.docc/HomomorphicEncryption.md)
-* [PrivateInformationRetrieval](Sources/PrivateInformationRetrieval/PrivateInformationRetrieval.docc/PrivateInformationRetrieval.md)
-* [HomomorphicEncryptionProtobuf](Sources/HomomorphicEncryptionProtobuf/HomomorphicEncryptionProtobuf.docc/HomomorphicEncryptionProtobuf.md)
-* [PrivateInformationRetrievalProtobuf](Sources/PrivateInformationRetrievalProtobuf/PrivateInformationRetrievalProtobuf.docc/PrivateInformationRetrievalProtobuf.md)
+* [HomomorphicEncryption](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption)
+* [PrivateInformationRetrieval](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrieval)
+* [HomomorphicEncryptionProtobuf](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryptionprotobuf)
+* [PrivateInformationRetrievalProtobuf](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrievalprotobuf)
 
 and executables:
-* [PIRGenerateDatabase](Sources/PIRGenerateDatabase/PIRGenerateDatabase.docc/PIRGenerateDatabase.md)
-* [PIRProcessDatabase](Sources/PIRProcessDatabase/PIRProcessDatabase.docc/PIRProcessDatabase.md)
-* [PIRShardDatabase](Sources/PIRShardDatabase/PIRShardDatabase.docc/PIRShardDatabase.md)
+* [PIRGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirgeneratedatabase)
+* [PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirprocessdatabase)
+* [PIRShardDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirsharddatabase)
 
 ## Background
 ### Homomorphic Encryption (HE)

--- a/Sources/HomomorphicEncryptionProtobuf/HomomorphicEncryptionProtobuf.docc/HomomorphicEncryptionProtobuf.md
+++ b/Sources/HomomorphicEncryptionProtobuf/HomomorphicEncryptionProtobuf.docc/HomomorphicEncryptionProtobuf.md
@@ -1,11 +1,11 @@
 # ``HomomorphicEncryptionProtobuf``
 
-Protocol buffer support for Homomorphic Encryption (HE)
+Protocol buffer support for [HomomorphicEncryption](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption)
 
 ## Overview
-`HomomorphicEncryptionProtobuf` contains supports for using `HomomorphicEncryption` (HE) with [protocol buffers](https://protobuf.dev/), commonly referred to as `protobuf`.
+`HomomorphicEncryptionProtobuf` contains supports for using [HomomorphicEncryption](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption) with [protocol buffers](https://protobuf.dev/), commonly referred to as `protobuf`.
 This module contains:
 * the generated Swift code to use the protobuf types.
-* conversion between protobuf types and `HomomorphicEncryption` runtime types.
+* conversion between protobuf types and [HomomorphicEncryption](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption) runtime types.
 
 The protobuf schemas are defined at [https://github.com/apple/swift-homomorphic-encryption-protobuf](https://github.com/apple/swift-homomorphic-encryption-protobuf).

--- a/Sources/PIRGenerateDatabase/PIRGenerateDatabase.docc/PIRGenerateDatabase.md
+++ b/Sources/PIRGenerateDatabase/PIRGenerateDatabase.docc/PIRGenerateDatabase.md
@@ -4,7 +4,7 @@ Keyword PIR database generation
 
 ## Overview
 
-`PIRGenerateDatabase` is a executable which generates a sample database for testing.
+`PIRGenerateDatabase` is an executable which generates a sample database for testing.
 The resulting database can be processed with the `PIRProcessDatabase` executable or sharded with the `PIRShardDatabase` executable.
 
 ### Requirements
@@ -29,7 +29,7 @@ PIRGenerateDatabase \
 
 This will generate a database of 100 rows, with keywords 0 to 100, and each value repeating the keyword for 10 to 20 bytes.
 
-The database is a serialized `KeywordDatabase` message.
+The database is a serialized [Apple_SwiftHomomorphicEncryption_Pir_V1_KeywordDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrievalprotobuf/apple_swifthomomorphicencryption_pir_v1_keyworddatabase).
 For readability, the `.txtpb` extension ensures the output database will be saved in protocol buffer text format.
 
 > Note: For a more compact format, use the `.binpb` extension to save the database in protocol buffer binary format.

--- a/Sources/PIRProcessDatabase/PIRProcessDatabase.docc/PIRProcessDatabase.md
+++ b/Sources/PIRProcessDatabase/PIRProcessDatabase.docc/PIRProcessDatabase.md
@@ -26,11 +26,10 @@ Run `PIRProcessDatabase --help` to get a sample JSON configuration.
 ### Required Configuration Parameters
 
 There are four required parameters:
-1. `rlweParameters` is one of the preset RLWE parameters listed in
-`Sources/HomomorphicEncryption/EncryptionParameters.swift`, e.g.,
-`n_4096_logq_27_28_28_logt_5`.
-2. `inputDatabase` is the path to the unprocessed input database. It must be a
-serialized ``PrivateInformationRetrieval/KeywordDatabase``.
+1. `rlweParameters` is one of the [PredefinedRlweParameters](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption/predefinedrlweparameters),
+e.g., `n_4096_logq_27_28_28_logt_5`.
+1. `inputDatabase` is the path to the unprocessed input database. It must be a
+serialized [Apple_SwiftHomomorphicEncryption_Pir_V1_KeywordDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrievalprotobuf/apple_swifthomomorphicencryption_pir_v1_keyworddatabase).
 
 > Note: The `PIRGenerateDatabase` binary can be used to generate a sample database.
 
@@ -53,8 +52,7 @@ A minimal configuration sample is
 }
 ```
 The only required parameter variable which affects performance is
-`rlweParameters`. These parameters are picked from a set of encryption parameters
-in [Sources/HomomorphicEncryption/EncryptionParameters.swift](github.com/apple/swift-homomorphic-encryption/Sources/Sources/HomomorphicEncryption/EncryptionParameters.swift).
+`rlweParameters`. These parameters are picked from a set of [PredefinedRlweParameters](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption/predefinedrlweparameters).
 RLWE parameters are defined by ring dimension `n`, a ciphertext modulus bit
 length `log q`, and plaintext modulus bit length, `log t`.
 

--- a/Sources/PIRShardDatabase/PIRShardDatabase.docc/PIRShardDatabase.md
+++ b/Sources/PIRShardDatabase/PIRShardDatabase.docc/PIRShardDatabase.md
@@ -4,22 +4,24 @@ Keyword PIR database sharding
 
 ## Overview
 
-`PIRShardDatabase` is a executable which divides a database into disjoint shards.
-Each resulting shard is suitable for processing with the `PIRProcessDatabase` executable.
+[PIRShardDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirsharddatabase) is an executable which divides a database into disjoint shards.
+Each resulting shard is suitable for processing with the [PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirprocessdatabase) executable.
 
 `PIRShardDatabase` supports two sharding settings:
 * `shardCount` randomly shards the database using the specified of shards.
 * `entryCountPerShard` shards the database using enough shards such that the average shard contains the specified number of entries.
 
 ### Requirements
-Build the `PIRProcessDatabase` executable by running:
+Build the [PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirprocessdatabase) executable by running:
 ```sh
 swift build -c release --target PIRProcessDatabase
 ```
 The binary will be generated in `.build/release/PIRProcessDatabase`.
 
-
-For the example below, you'll also need to install the `PIRGenerateDatabase` executable in a similar manner as `PIRShardDatabase`.
+For the example below, you'll also need to install the
+[PIRGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirgeneratedatabse)
+executable in a similar manner as
+[PIRShardDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirsharddatabase).
 
 ### Example
 

--- a/Sources/PrivateInformationRetrieval/PrivateInformationRetrieval.docc/ParameterTuning.md
+++ b/Sources/PrivateInformationRetrieval/PrivateInformationRetrieval.docc/ParameterTuning.md
@@ -10,7 +10,7 @@ Notably, Keyword PIR's server runtime is linear in the shard size,
 independent of the keyword size, and dependent on the value size.
 Large values, such as images, should be compressed when possible.
 Parameters are read in by a JSON file as described in-detail in
-`PIRProcessDatabase.md`.
+[PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirprocessdatabase) documentation.
 
 ```sh
 PIRProcessDatabase ~/config.json
@@ -35,7 +35,7 @@ PIRs automatically. For thin databases, smaller RLWE plaintexts in
 fits many buckets. Large plaintexts are more efficient for
 wide databases.
 
-Otherwise, the observed `noiseBudget` is an important parameter to track. If it is low,
+Otherwise, the observed [noise budget](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption/hescheme/noisebudget(of:using:variabletime:)-143f3) is an important parameter to track. If it is low,
 then it is best to increase the ciphertext-to-plaintext modulus ratio.
 This can be done by either decreasing the plaintext modulus with the same ring dimension
 or increasing the ring dimension and ciphertext modulus while keeping the
@@ -48,8 +48,7 @@ Here, thin databases benefit from using one hash function, `hashFunctionCount` =
 instead of two when constructing the cuckoo table. This is because many more entries
 will fit in one ciphertext and only one ciphertext is sent back to the client.
 Response sizes are smaller as a result. Settings with
-one hash function can also have a smaller `targetLoadFactor`, e.g., something
-like 0.75 instead of the 0.9.
+one hash function can also have a smaller `targetLoadFactor`, e.g., 0.75 instead of 0.9.
 
 The parameter `bucketCount` should mostly be used in the `allowExpansion` form.
 Otherwise, `bucketCount` can be set manually with `fixedSize` and `bucketCount`
@@ -57,6 +56,12 @@ as the number of buckets per database. More buckets means smaller communication 
 larger computation times.
 
 ### Examples
+
+The examples rely on the
+[PIRGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirgeneratedatabase)
+and
+[PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirprocessdatabase)
+executables.
 
 #### Thin Database
 ```sh
@@ -67,7 +72,7 @@ PIRGenerateDatabase \
     --value-type random
 ```
 
-Say we run `PIRProcessDatabase` RLWE
+Say we run `PIRProcessDatabase` with RLWE
 parameters `n_4096_logq_27_28_28_logt_4`, one shard, and see the
 following:
 * An evaluation key size of 680.8 KB.

--- a/Sources/PrivateInformationRetrievalProtobuf/PrivateInformationRetrievalProtobuf.docc/PrivateInformationRetrievalProtobuf.md
+++ b/Sources/PrivateInformationRetrievalProtobuf/PrivateInformationRetrievalProtobuf.docc/PrivateInformationRetrievalProtobuf.md
@@ -1,11 +1,11 @@
 # ``PrivateInformationRetrievalProtobuf``
 
-Protocol buffer support for Private Information Retrieval (PIR)
+Protocol buffer support for [PrivateInformationRetrieval](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrieval)
 
 ## Overview
-`PrivateInformationRetrievalProtobuf` contains supports for using `Private Information Retrieval` (PIR) with [protocol buffers](https://protobuf.dev/), commonly referred to as `protobuf`.
+`PrivateInformationRetrievalProtobuf` contains supports for using [PrivateInformationRetrieval](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrieval) with [protocol buffers](https://protobuf.dev/), commonly referred to as `protobuf`.
 This module contains:
 * the generated Swift code to use the protobuf types.
-* conversion between protobuf types and `PrivateInformationRetrievalProtobuf` runtime types.
+* conversion between protobuf types and [PrivateInformationRetrieval](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrieval) runtime types.
 
 The protobuf schemas are defined at [https://github.com/apple/swift-homomorphic-encryption-protobuf](https://github.com/apple/swift-homomorphic-encryption-protobuf).


### PR DESCRIPTION
Update documentation with some links from https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption.