### PR TITLE
Disallow multipleTables == false in KeywordPirConfig

### DIFF
--- a/Sources/PrivateInformationRetrieval/KeywordPirProtocol.swift
+++ b/Sources/PrivateInformationRetrieval/KeywordPirProtocol.swift
@@ -46,6 +46,9 @@ public struct KeywordPirConfig: Hashable, Codable {
         guard validDimensionsCount.contains(dimensionCount) else {
             throw PirError.invalidDimensionCount(dimensionCount: dimensionCount, expected: validDimensionsCount)
         }
+        guard cuckooTableConfig.multipleTables else {
+            throw PirError.invalidCuckooConfig(config: cuckooTableConfig)
+        }
         self.dimensionCount = dimensionCount
         self.cuckooTableConfig = cuckooTableConfig
         self.unevenDimensions = unevenDimensions


### PR DESCRIPTION
`multipleTables: true` should always be preferred for our PIR implementation (for `hashFunctionCount == 1`, it makes no difference)