### PR TITLE
Make Ciphertext.noiseBudget generic

### DIFF
--- a/Sources/HomomorphicEncryption/Bfv/Bfv+Decrypt.swift
+++ b/Sources/HomomorphicEncryption/Bfv/Bfv+Decrypt.swift
@@ -39,7 +39,7 @@ extension Bfv {
 
     @inlinable
     // swiftlint:disable:next missing_docs attributes
-    public static func noiseBudget(
+    public static func noiseBudgetEval(
         of ciphertext: EvalCiphertext,
         using secretKey: SecretKey<Bfv<T>>,
         variableTime: Bool) throws -> Double
@@ -90,10 +90,10 @@ extension Bfv {
 
     @inlinable
     // swiftlint:disable:next missing_docs attributes
-    public static func noiseBudget(of ciphertext: CoeffCiphertext,
-                                   using secretKey: SecretKey<Bfv<T>>, variableTime: Bool) throws -> Double
+    public static func noiseBudgetCoeff(of ciphertext: CoeffCiphertext,
+                                        using secretKey: SecretKey<Bfv<T>>, variableTime: Bool) throws -> Double
     {
-        try noiseBudget(of: ciphertext.convertToEvalFormat(), using: secretKey, variableTime: variableTime)
+        try noiseBudgetEval(of: ciphertext.convertToEvalFormat(), using: secretKey, variableTime: variableTime)
     }
 
     @inlinable

--- a/Sources/HomomorphicEncryption/EncryptionParameters.swift
+++ b/Sources/HomomorphicEncryption/EncryptionParameters.swift
@@ -66,7 +66,7 @@ public struct EncryptionParameters<Scheme: HeScheme>: Hashable, Codable, Sendabl
     ///
     /// and should generally be chosen as the largest of the coefficient moduli to minimize noise growth on those
     /// operations.
-    /// - seealso: ``HeScheme/noiseBudget(of:using:variableTime:)-5p5m0``
+    /// - seealso: ``Ciphertext/noiseBudget(using:variableTime:)``
     public let coefficientModuli: [Scheme.Scalar]
 
     /// RLWE error polynomial standard deviation.

--- a/Sources/HomomorphicEncryption/Error.swift
+++ b/Sources/HomomorphicEncryption/Error.swift
@@ -20,7 +20,7 @@ public enum HeError: Error, Equatable {
     case emptyModulus
     case encodingDataCountExceedsLimit(count: Int, limit: Int)
     case encodingDataExceedsLimit(limit: Int)
-    case errorInSameFormatCasting(_ description: String)
+    case errorCastingPolyFormat(_ description: String)
     case incompatibleCiphertextAndPlaintext(_ description: String)
     case incompatibleCiphertextCount(_ description: String)
     case incompatibleCiphertexts(_ description: String)
@@ -52,8 +52,8 @@ public enum HeError: Error, Equatable {
 
 extension HeError {
     @inlinable
-    static func errorInSameFormatCasting(_ t1: (some PolyFormat).Type, _ t2: (some PolyFormat).Type) -> Self {
-        .errorInSameFormatCasting("Cast Format1: \(t1.description)to Format1: \(t2.description)")
+    static func errorCastingPolyFormat(from t1: (some PolyFormat).Type, to t2: (some PolyFormat).Type) -> Self {
+        .errorCastingPolyFormat("Error casting poly format from: \(t1.description) to: \(t2.description)")
     }
 
     @inlinable
@@ -178,8 +178,8 @@ extension HeError: LocalizedError {
             "Actual number of data \(count) exceeds limit \(limit)"
         case let .encodingDataExceedsLimit(limit):
             "Actual data exceeds limit \(limit)"
-        case let .errorInSameFormatCasting(description):
-            "Error in same format casting: \(description) "
+        case let .errorCastingPolyFormat(description):
+            "\(description) "
         case let .incompatibleCiphertextCount(description):
             "\(description)"
         case let .incompatibleCiphertexts(description):

--- a/Sources/HomomorphicEncryption/HeScheme.swift
+++ b/Sources/HomomorphicEncryption/HeScheme.swift
@@ -83,15 +83,14 @@ public protocol HeScheme {
 
     /// Ciphertext in ``Eval`` format.
     ///
-    /// ``Ciphertext/convertToEvalFormat()`` can be used to convert a ciphertext to a ``CoeffCiphertext``.
+    /// ``Ciphertext/convertToEvalFormat()`` can be used to convert a ciphertext to an ``EvalCiphertext``.
     typealias EvalCiphertext = Ciphertext<Self, Eval>
 
     /// The canonical representation of a ciphertext.
     ///
     /// The canonical representation is the default ciphertext representation.
-    /// ``Ciphertext/convertToCanonicalFormat()-1ouc4``
-    /// can be used to convert a ciphertext to a ``CoeffCiphertext``. However, some operations may require a specific
-    /// format, such as ``CoeffCiphertext`` or ``EvalCiphertext``.
+    /// ``Ciphertext/convertToCanonicalFormat()`` can be used to convert a ciphertext to a ``CanonicalCiphertext``.
+    /// However, some operations may require a specific format, such as ``CoeffCiphertext`` or ``EvalCiphertext``.
     typealias CanonicalCiphertext = Ciphertext<Self, CanonicalCiphertextFormat>
 
     /// Secret key type.
@@ -109,7 +108,7 @@ public protocol HeScheme {
 
     /// The minimum `noise budget` to guarantee a successful decryption.
     ///
-    /// - seealso: ``HeScheme/noiseBudget(of:using:variableTime:)-5p5m0``.
+    /// - seealso: ``Ciphertext/noiseBudget(using:variableTime:)``.
     static var minNoiseBudget: Double { get }
 
     /// Generates a ``SecretKey``.
@@ -271,8 +270,7 @@ public protocol HeScheme {
     /// - Returns: The plaintext decryption of the ciphertext.
     /// - Throws: Error upon failure to decrypt.
     /// - Warning: The ciphertext must have at least ``HeScheme/minNoiseBudget`` noise to ensure accurate decryption.
-    ///  - seealso: The noise budget can be computed using
-    ///  ``HeScheme/noiseBudget(of:using:variableTime:)-143f3``.
+    ///  - seealso: The noise budget can be computed using ``Ciphertext/noiseBudget(using:variableTime:)``.
     ///  - seealso: ``Ciphertext/decrypt(using:)`` for an alternative API.
     static func decryptCoeff(_ ciphertext: CoeffCiphertext, using secretKey: SecretKey) throws -> CoeffPlaintext
 
@@ -283,8 +281,7 @@ public protocol HeScheme {
     /// - Returns: The plaintext decryption of the ciphertext.
     /// - Throws: Error upon failure to decrypt.
     /// - Warning: The ciphertext must have at least ``HeScheme/minNoiseBudget`` noise to ensure accurate decryption.
-    ///  - seealso: The noise budget can be computed using
-    ///  ``HeScheme/noiseBudget(of:using:variableTime:)-7vpza``.
+    ///  - seealso: The noise budget can be computed using ``Ciphertext/noiseBudget(using:variableTime:)``.
     ///  - seealso: ``Ciphertext/decrypt(using:)`` for an alternative API.
     static func decryptEval(_ ciphertext: EvalCiphertext, using secretKey: SecretKey) throws -> CoeffPlaintext
 
@@ -552,10 +549,9 @@ public protocol HeScheme {
     /// Modulus switching drops the last coefficient modulus in the ciphertext's current ciphertext modulus, without
     /// affecting the value of the plaintext after decryption. Modulus switching reduces the runtime, serialization
     /// size, and memory overhead of the resulting ciphertext. However, it may also reduce the noise budget (see
-    /// ``HeScheme/noiseBudget(of:using:variableTime:)-5p5m0``) of the ciphertext. The ideal time to mod switch
-    /// therefore
-    /// depends on the encrypted circuit. A simple guideline is to `modSwitchDown` immediately prior to serialization
-    /// and sending the ciphertext to the secret key owner.
+    /// ``Ciphertext/noiseBudget(using:variableTime:)``) of the ciphertext. The ideal time to mod switch
+    /// therefore depends on the encrypted circuit. A simple guideline is to `modSwitchDown` immediately prior to
+    /// serialization and sending the ciphertext to the secret key owner.
     /// - Parameter ciphertext: Ciphertext; must have > 1 ciphertext modulus.
     /// - Throws: Error upon failure to mod-switch.
     /// - seealso: ``Ciphertext/modSwitchDown()`` for an alternative API.
@@ -618,8 +614,8 @@ public protocol HeScheme {
     /// - Returns: The noise budget.
     /// - Throws: Error upon failure to compute the noise budget.
     /// - Warning: Leaks `secretKey` through timing. Should be used for testing only.
-    /// - seealso: ``Ciphertext/noiseBudget(using:variableTime:)-7dicj`` for an alternative API.
-    static func noiseBudget(of ciphertext: CanonicalCiphertext, using secretKey: SecretKey, variableTime: Bool) throws
+    /// - seealso: ``Ciphertext/noiseBudget(using:variableTime:)`` for an alternative API.
+    static func noiseBudgetCoeff(of ciphertext: CoeffCiphertext, using secretKey: SecretKey, variableTime: Bool) throws
         -> Double
 
     /// Computes the noise budget of a ciphertext.
@@ -633,23 +629,8 @@ public protocol HeScheme {
     /// - Returns: The noise budget.
     /// - Throws: Error upon failure to compute the noise budget.
     /// - Warning: Leaks `secretKey` through timing. Should be used for testing only.
-    /// - seealso: ``Ciphertext/noiseBudget(using:variableTime:)-6ha4l`` for an alternative API.
-    static func noiseBudget(of ciphertext: CoeffCiphertext, using secretKey: SecretKey, variableTime: Bool) throws
-        -> Double
-
-    /// Computes the noise budget of a ciphertext.
-    ///
-    /// The *noise budget* of a ciphertext decreases throughout HE operations. Once a ciphertext's noise budget is below
-    /// ``HeScheme/minNoiseBudget``, decryption may yield inaccurate plaintexts.
-    /// - Parameters:
-    ///   - ciphertext: Ciphertext whose noise budget to compute.
-    ///   - secretKey: Secret key.
-    ///   - variableTime: Must be `true`, indicating the secret key coefficients are leaked through timing.
-    /// - Returns: The noise budget.
-    /// - Throws: Error upon failure to compute the noise budget.
-    /// - Warning: Leaks `secretKey` through timing. Should be used for testing only.
-    /// - seealso: ``Ciphertext/noiseBudget(using:variableTime:)-39n1i`` for an alternative API.
-    static func noiseBudget(of ciphertext: EvalCiphertext, using secretKey: SecretKey, variableTime: Bool) throws
+    /// - seealso: ``Ciphertext/noiseBudget(using:variableTime:)`` for an alternative API.
+    static func noiseBudgetEval(of ciphertext: EvalCiphertext, using secretKey: SecretKey, variableTime: Bool) throws
         -> Double
 }
 
@@ -661,8 +642,7 @@ extension HeScheme {
     /// - Returns: The plaintext decryption of the ciphertext.
     /// - Throws: Error upon failure to decrypt.
     /// - Warning: The ciphertext must have at least ``HeScheme/minNoiseBudget`` noise to ensure accurate decryption.
-    ///  - seealso: The noise budget can be computed using
-    ///  ``HeScheme/noiseBudget(of:using:variableTime:)-5p5m0``.
+    ///  - seealso: The noise budget can be computed using ``Ciphertext/noiseBudget(using:variableTime:)``.
     ///  - seealso: ``Ciphertext/decrypt(using:)`` for an alternative API.
     @inlinable
     public static func decrypt<Format: PolyFormat>(_ ciphertext: Ciphertext<Self, Format>,
@@ -820,6 +800,39 @@ extension HeScheme {
         } else {
             fatalError("Unsupported Format \(LhsFormat.description)")
         }
+        // swiftlint:enable force_cast
+    }
+
+    /// Computes the noise budget of a ciphertext.
+    ///
+    /// The *noise budget* of a ciphertext decreases throughout HE operations. Once a ciphertext's noise budget is below
+    /// ``HeScheme/minNoiseBudget``, decryption may yield inaccurate plaintexts.
+    /// - Parameters:
+    ///   - ciphertext: Ciphertext whose noise budget to compute.
+    ///   - secretKey: Secret key.
+    ///   - variableTime: Must be `true`, indicating the secret key coefficients are leaked through timing.
+    /// - Returns: The noise budget.
+    /// - Throws: Error upon failure to compute the noise budget.
+    /// - Warning: Leaks `secretKey` through timing. Should be used for testing only.
+    /// - seealso: ``Ciphertext/noiseBudget(using:variableTime:)`` for an alternative API.
+    @inlinable
+    public static func noiseBudget<Format: PolyFormat>(
+        of ciphertext: Ciphertext<Self, Format>,
+        using secretKey: SecretKey,
+        variableTime: Bool) throws
+        -> Double
+    {
+        // swiftlint:disable force_cast
+        if Format.self == Coeff.self {
+            return try noiseBudgetCoeff(
+                of: ciphertext as! CoeffCiphertext,
+                using: secretKey,
+                variableTime: variableTime)
+        }
+        if Format.self == Eval.self {
+            return try noiseBudgetEval(of: ciphertext as! EvalCiphertext, using: secretKey, variableTime: variableTime)
+        }
+        fatalError("Unsupported Format \(Format.description)")
         // swiftlint:enable force_cast
     }
 }

--- a/Sources/HomomorphicEncryption/NoOpScheme.swift
+++ b/Sources/HomomorphicEncryption/NoOpScheme.swift
@@ -276,14 +276,14 @@ public enum NoOpScheme: HeScheme {
 
     public static func relinearize(_: inout CanonicalCiphertext, using _: EvaluationKey<Self>) throws {}
 
-    public static func noiseBudget(of _: CanonicalCiphertext, using _: SecretKey<Self>,
-                                   variableTime _: Bool) throws -> Double
+    public static func noiseBudgetCoeff(of _: CoeffCiphertext, using _: SecretKey<Self>,
+                                        variableTime _: Bool) throws -> Double
     {
         minNoiseBudget
     }
 
-    public static func noiseBudget(of _: EvalCiphertext, using _: SecretKey<Self>,
-                                   variableTime _: Bool) throws -> Double
+    public static func noiseBudgetEval(of _: EvalCiphertext, using _: SecretKey<Self>,
+                                       variableTime _: Bool) throws -> Double
     {
         minNoiseBudget
     }

--- a/Sources/HomomorphicEncryption/PolyRq/PolyRq.swift
+++ b/Sources/HomomorphicEncryption/PolyRq/PolyRq.swift
@@ -432,12 +432,12 @@ extension PolyRq {
         switch F.self {
         case is Coeff.Type:
             guard let poly = self as? PolyRq<T, Coeff> else {
-                throw HeError.errorInSameFormatCasting(F.self, Coeff.self)
+                throw HeError.errorCastingPolyFormat(from: F.self, to: Coeff.self)
             }
             return poly
         default:
             guard let poly = self as? PolyRq<T, Eval> else {
-                throw HeError.errorInSameFormatCasting(F.self, Eval.self)
+                throw HeError.errorCastingPolyFormat(from: F.self, to: Eval.self)
             }
             return try poly.inverseNtt()
         }
@@ -452,12 +452,12 @@ extension PolyRq {
         switch F.self {
         case is Coeff.Type:
             guard let poly = self as? PolyRq<T, Coeff> else {
-                throw HeError.errorInSameFormatCasting(F.self, Coeff.self)
+                throw HeError.errorCastingPolyFormat(from: F.self, to: Coeff.self)
             }
             return try poly.forwardNtt()
         default:
             guard let poly = self as? PolyRq<T, Eval> else {
-                throw HeError.errorInSameFormatCasting(F.self, Eval.self)
+                throw HeError.errorCastingPolyFormat(from: F.self, to: Eval.self)
             }
             return poly
         }
@@ -472,17 +472,17 @@ extension PolyRq {
         switch Format.self {
         case is Coeff.Type:
             guard let poly = try convertToCoeff() as? PolyRq<T, Format> else {
-                throw HeError.errorInSameFormatCasting(Format.self, F.self)
+                throw HeError.errorCastingPolyFormat(from: F.self, to: Format.self)
             }
             return poly
         case is Eval.Type:
             guard let poly = try convertToEval() as? PolyRq<T, Format> else {
-                throw HeError.errorInSameFormatCasting(Format.self, F.self)
+                throw HeError.errorCastingPolyFormat(from: F.self, to: Format.self)
             }
             return poly
         default:
             guard let poly = self as? PolyRq<T, Format> else {
-                throw HeError.errorInSameFormatCasting(Format.self, F.self)
+                throw HeError.errorCastingPolyFormat(from: F.self, to: Format.self)
             }
             return poly
         }

--- a/Tests/HomomorphicEncryptionTests/HeAPITests.swift
+++ b/Tests/HomomorphicEncryptionTests/HeAPITests.swift
@@ -996,6 +996,18 @@ class HeAPITests: XCTestCase {
 
         var noiseBudget = try Bfv<T>.noiseBudget(of: ciphertext, using: testEnv.secretKey, variableTime: true)
         XCTAssert(noiseBudget > 0)
+
+        let coeffNoiseBudget = try Bfv<T>.noiseBudget(
+            of: ciphertext.convertToCoeffFormat(),
+            using: testEnv.secretKey,
+            variableTime: true)
+        let canonicalNoiseBudget = try Bfv<T>.noiseBudget(
+            of: ciphertext.convertToCanonicalFormat(),
+            using: testEnv.secretKey,
+            variableTime: true)
+        XCTAssertEqual(coeffNoiseBudget, noiseBudget)
+        XCTAssertEqual(canonicalNoiseBudget, noiseBudget)
+
         while noiseBudget > Bfv<T>.minNoiseBudget + 1 {
             ciphertext = try ciphertext + ciphertext
             try expected += expected


### PR DESCRIPTION
* Make `Ciphertext/noiseBudget` work on all ciphertext types
* Make `Ciphertext/convertTo{Coeff,Eval,Canonical}` format work on all ciphertext types
* Breaking API change: renaming `errorInSameFormatCasting` to `errorCastingPolyFormat`.