### PR TITLE
Remove unimplemented operations from HeScheme

### DIFF
--- a/Sources/HomomorphicEncryption/Bfv/Bfv.swift
+++ b/Sources/HomomorphicEncryption/Bfv/Bfv.swift
@@ -134,27 +134,7 @@ public enum Bfv<T: ScalarType>: HeScheme {
     // keep NTT conversions explicit
 
     @inlinable
-    public static func addAssignCoeffEval(_: inout CoeffCiphertext, _: EvalPlaintext) throws {
-        throw HeError.unsupportedHeOperation()
-    }
-
-    @inlinable
-    public static func addAssignEvalCoeff(_: inout EvalCiphertext, _: CoeffPlaintext) throws {
-        throw HeError.unsupportedHeOperation()
-    }
-
-    @inlinable
     public static func addAssignEval(_: inout EvalCiphertext, _: EvalPlaintext) throws {
-        throw HeError.unsupportedHeOperation()
-    }
-
-    @inlinable
-    public static func subAssignCoeffEval(_: inout CoeffCiphertext, _: EvalPlaintext) throws {
-        throw HeError.unsupportedHeOperation()
-    }
-
-    @inlinable
-    public static func subAssignEvalCoeff(_: inout EvalCiphertext, _: CoeffPlaintext) throws {
         throw HeError.unsupportedHeOperation()
     }
 

--- a/Sources/HomomorphicEncryption/HeScheme.swift
+++ b/Sources/HomomorphicEncryption/HeScheme.swift
@@ -379,23 +379,7 @@ public protocol HeScheme {
     ///   - ciphertext: Ciphertext to add; will store the sum.
     ///   - plaintext: Plaintext to add.
     /// - Throws: Error upon failure to add.
-    static func addAssignCoeffEval(_ ciphertext: inout CoeffCiphertext, _ plaintext: EvalPlaintext) throws
-
-    /// In-place ciphertext-plaintext addition: `ciphertext += plaintext`.
-    ///
-    /// - Parameters:
-    ///   - ciphertext: Ciphertext to add; will store the sum.
-    ///   - plaintext: Plaintext to add.
-    /// - Throws: Error upon failure to add.
     static func addAssignEval(_ ciphertext: inout EvalCiphertext, _ plaintext: EvalPlaintext) throws
-
-    /// In-place ciphertext-plaintext addition: `ciphertext += plaintext`.
-    ///
-    /// - Parameters:
-    ///   - ciphertext: Ciphertext to add; will store the sum.
-    ///   - plaintext: Plaintext to add.
-    /// - Throws: Error upon failure to add.
-    static func addAssignEvalCoeff(_ ciphertext: inout EvalCiphertext, _ plaintext: CoeffPlaintext) throws
 
     /// In-place ciphertext-plaintext subtraction: `ciphertext -= plaintext`.
     ///
@@ -411,23 +395,7 @@ public protocol HeScheme {
     ///   - ciphertext: Ciphertext to subtract from; will store the difference.
     ///   - plaintext: Plaintext to subtract.
     /// - Throws: Error upon failure to subtract.
-    static func subAssignCoeffEval(_ ciphertext: inout CoeffCiphertext, _ plaintext: EvalPlaintext) throws
-
-    /// In-place ciphertext-plaintext subtraction: `ciphertext -= plaintext`.
-    ///
-    /// - Parameters:
-    ///   - ciphertext: Ciphertext to subtract from; will store the difference.
-    ///   - plaintext: Plaintext to subtract.
-    /// - Throws: Error upon failure to subtract.
     static func subAssignEval(_ ciphertext: inout EvalCiphertext, _ plaintext: EvalPlaintext) throws
-
-    /// In-place ciphertext-plaintext subtraction: `ciphertext -= plaintext`.
-    ///
-    /// - Parameters:
-    ///   - ciphertext: Ciphertext to subtract from; will store the difference.
-    ///   - plaintext: Plaintext to subtract.
-    /// - Throws: Error upon failure to subtract.
-    static func subAssignEvalCoeff(_ ciphertext: inout EvalCiphertext, _ plaintext: CoeffPlaintext) throws
 
     /// In-place ciphertext-plaintext multiplication: `ciphertext *= plaintext`.
     ///
@@ -657,28 +625,20 @@ extension HeScheme {
         _ plaintext: Plaintext<Self, PlaintextFormat>) throws
     {
         // swiftlint:disable force_cast
-        if CiphertextFormat.self == Coeff.self {
+        if CiphertextFormat.self == Coeff.self, PlaintextFormat.self == Coeff.self {
             var coeffCiphertext = ciphertext as! CoeffCiphertext
-            if PlaintextFormat.self == Coeff.self {
-                try addAssignCoeff(&coeffCiphertext, plaintext as! CoeffPlaintext)
-            } else if PlaintextFormat.self == Eval.self {
-                try addAssignCoeffEval(&coeffCiphertext, plaintext as! EvalPlaintext)
-            } else {
-                fatalError("Unsupported PlaintextFormat \(PlaintextFormat.description)")
-            }
+            try addAssignCoeff(&coeffCiphertext, plaintext as! CoeffPlaintext)
             ciphertext = coeffCiphertext as! Ciphertext<Self, CiphertextFormat>
-        } else if CiphertextFormat.self == Eval.self {
+        } else if CiphertextFormat.self == Eval.self, PlaintextFormat.self == Eval.self {
             var evalCiphertext = ciphertext as! EvalCiphertext
-            if PlaintextFormat.self == Coeff.self {
-                try addAssignEvalCoeff(&evalCiphertext, plaintext as! CoeffPlaintext)
-            } else if PlaintextFormat.self == Eval.self {
-                try addAssignEval(&evalCiphertext, plaintext as! EvalPlaintext)
-            } else {
-                fatalError("Unsupported PlaintextFormat \(PlaintextFormat.description)")
-            }
+            try addAssignEval(&evalCiphertext, plaintext as! EvalPlaintext)
             ciphertext = evalCiphertext as! Ciphertext<Self, CiphertextFormat>
         } else {
-            fatalError("Unsupported CiphertextFormat \(CiphertextFormat.description)")
+            throw HeError.unsupportedHeOperation(
+                """
+                Addition between ciphertext in \(CiphertextFormat.description) \
+                and plaintext in \(PlaintextFormat.description).
+                """)
         }
         // swiftlint:enable force_cast
     }
@@ -729,28 +689,20 @@ extension HeScheme {
         _ plaintext: Plaintext<Self, PlaintextFormat>) throws
     {
         // swiftlint:disable force_cast
-        if CiphertextFormat.self == Coeff.self {
-            var coeffCiphertext = ciphertext as! Ciphertext<Self, Coeff>
-            if PlaintextFormat.self == Coeff.self {
-                try subAssignCoeff(&coeffCiphertext, plaintext as! CoeffPlaintext)
-            } else if PlaintextFormat.self == Eval.self {
-                try subAssignCoeffEval(&coeffCiphertext, plaintext as! EvalPlaintext)
-            } else {
-                fatalError("Unsupported PlaintextFormat \(PlaintextFormat.description)")
-            }
+        if CiphertextFormat.self == Coeff.self, PlaintextFormat.self == Coeff.self {
+            var coeffCiphertext = ciphertext as! CoeffCiphertext
+            try subAssignCoeff(&coeffCiphertext, plaintext as! CoeffPlaintext)
             ciphertext = coeffCiphertext as! Ciphertext<Self, CiphertextFormat>
-        } else if CiphertextFormat.self == Eval.self {
-            var evalCiphertext = ciphertext as! Ciphertext<Self, Eval>
-            if PlaintextFormat.self == Coeff.self {
-                try subAssignEvalCoeff(&evalCiphertext, plaintext as! CoeffPlaintext)
-            } else if PlaintextFormat.self == Eval.self {
-                try subAssignEval(&evalCiphertext, plaintext as! EvalPlaintext)
-            } else {
-                fatalError("Unsupported PlaintextFormat \(PlaintextFormat.description)")
-            }
+        } else if CiphertextFormat.self == Eval.self, PlaintextFormat.self == Eval.self {
+            var evalCiphertext = ciphertext as! EvalCiphertext
+            try subAssignEval(&evalCiphertext, plaintext as! EvalPlaintext)
             ciphertext = evalCiphertext as! Ciphertext<Self, CiphertextFormat>
         } else {
-            fatalError("Unsupported CiphertextFormat \(CiphertextFormat.description)")
+            throw HeError.unsupportedHeOperation(
+                """
+                Subtraction between ciphertext in \(CiphertextFormat.description) \
+                and plaintext in \(PlaintextFormat.description).
+                """)
         }
         // swiftlint:enable force_cast
     }

--- a/Sources/HomomorphicEncryption/NoOpScheme.swift
+++ b/Sources/HomomorphicEncryption/NoOpScheme.swift
@@ -152,16 +152,6 @@ public enum NoOpScheme: HeScheme {
         ciphertext.polys[0] += plaintext.poly
     }
 
-    public static func addAssignCoeffEval(_ ciphertext: inout CoeffCiphertext, _ plaintext: EvalPlaintext) throws {
-        try addAssign(&ciphertext, plaintext.inverseNtt())
-    }
-
-    public static func addAssignEvalCoeff(_ ciphertext: inout EvalCiphertext, _ plaintext: CoeffPlaintext) throws {
-        try validateEquality(of: ciphertext.context, and: plaintext.context)
-        let evalPlaintext = try plaintext.forwardNtt()
-        try addAssign(&ciphertext, evalPlaintext)
-    }
-
     public static func addAssignEval(_ ciphertext: inout EvalCiphertext, _ plaintext: EvalPlaintext) throws {
         try validateEquality(of: ciphertext.context, and: plaintext.context)
         ciphertext.polys[0] += plaintext.poly
@@ -172,14 +162,6 @@ public enum NoOpScheme: HeScheme {
     public static func subAssignCoeff(_ ciphertext: inout CoeffCiphertext, _ plaintext: CoeffPlaintext) throws {
         try validateEquality(of: ciphertext.context, and: plaintext.context)
         ciphertext.polys[0] -= plaintext.poly
-    }
-
-    public static func subAssignCoeffEval(_ ciphertext: inout CoeffCiphertext, _ plaintext: EvalPlaintext) throws {
-        try subAssignCoeff(&ciphertext, plaintext.inverseNtt())
-    }
-
-    public static func subAssignEvalCoeff(_ ciphertext: inout EvalCiphertext, _ plaintext: CoeffPlaintext) throws {
-        try subAssignEval(&ciphertext, plaintext.forwardNtt())
     }
 
     public static func subAssignEval(_ ciphertext: inout EvalCiphertext, _ plaintext: EvalPlaintext) throws {


### PR DESCRIPTION
I also looked at the `addAssignEval` and `subAssignEval`. The scale-and-round part does not work in evaluation format so they are left unimplemented in BFV. But I left them in `HeScheme`, because other schemes might want to implement them when scale-and-round is not needed. I believe that is the case in BGV.