### PR TITLE
Use platform: linux for spi.yml docs

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -23,3 +23,4 @@ builder:
       - PIRGenerateDatabase
       - PIRProcessDatabase
       - PIRShardDatabase
+    - platform: linux


### PR DESCRIPTION
This might fix the missing articles on the HomomorphicEncryption page.

https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption

The articles still show up on the release https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.0-alpha.3/documentation/homomorphicencryption page. So almost surely this is due to an issue with Snippets (https://github.com/apple/swift-homomorphic-encryption/pull/35).

Swift-nio seems to be the [only](https://github.com/search?q=org%3Aapple+%22%40Snippet%22+language%3AMarkdown+&type=code) other Apple project that uses a snippet [here](https://github.com/apple/swift-nio/blob/0d2f72172f01123dad278ccf579b3feeaaa0cfda/Sources/NIOFileSystem/Docs.docc/index.md?plain=1#L26), and that seems to render fine [here](https://swiftpackageindex.com/apple/swift-nio/main/documentation/_NIOFileSystem#A-Brief-Tour). Their spi.yml [file](https://github.com/apple/swift-nio/blob/0d2f72172f01123dad278ccf579b3feeaaa0cfda/.spi.yml) doesn't have `platform: linux`, so this is just a guess. If this doesn't fix the rendered documentation, we can try moving the snippet out of the `Snippets/HomomorphicEncryption` folder and back into `Snippets`.