### PR TITLE
Add more checks for PirAlgorithm

### DIFF
--- a/Sources/PIRProcessDatabase/ProcessDatabase.swift
+++ b/Sources/PIRProcessDatabase/ProcessDatabase.swift
@@ -307,10 +307,10 @@ struct ProcessDatabase: ParsableCommand {
             keywordPirConfig: keywordConfig)
 
         let encryptionParameters = try EncryptionParameters<Scheme>(from: config.rlweParameters)
-        let processArgs = ProcessKeywordDatabase.Arguments<Scheme>(databaseConfig: databaseConfig,
-                                                                   encryptionParameters: encryptionParameters,
-                                                                   algorithm: config.algorithm,
-                                                                   trialsPerShard: config.trialsPerShard)
+        let processArgs = try ProcessKeywordDatabase.Arguments<Scheme>(databaseConfig: databaseConfig,
+                                                                       encryptionParameters: encryptionParameters,
+                                                                       algorithm: config.algorithm,
+                                                                       trialsPerShard: config.trialsPerShard)
 
         var evaluationKeyConfig = EvaluationKeyConfiguration()
         let context = try Context(encryptionParameters: processArgs.encryptionParameters)

--- a/Sources/PrivateInformationRetrieval/Error.swift
+++ b/Sources/PrivateInformationRetrieval/Error.swift
@@ -33,6 +33,7 @@ public enum PirError: Error, Hashable, Codable {
     case invalidHashBucketEntryValueSize(maxSize: Int)
     case invalidHashBucketSlotCount(maxCount: Int)
     case invalidIndex(index: Int, numberOfEntries: Int)
+    case invalidPirAlgorithm(_ pirAlgorithm: PirAlgorithm)
     case invalidReply(ciphertextCount: Int, expected: Int)
     case invalidResponse(replyCount: Int, expected: Int)
     case invalidSharding(_ description: String)
@@ -94,6 +95,8 @@ extension PirError: LocalizedError {
             "Invalid hash bucket slot count; maximum is \(maxCount)"
         case let .invalidIndex(index, numberOfEntries):
             "Index \(index) should between 0 and \(numberOfEntries)"
+        case let .invalidPirAlgorithm(pirAlgorithm):
+            "Invalid PIR algorithm: \(pirAlgorithm)"
         case let .invalidReply(ciphertextCount, expected):
             "Reply has \(ciphertextCount) ciphertexts, expected \(expected)"
         case let .invalidResponse(replyCount, expected):


### PR DESCRIPTION
As noted in https://github.com/apple/swift-homomorphic-encryption/issues/39#issue-2438955674, we have an enum value for `AclsPir`. But AclsPir isn't implemented yet, so this PR adds some checks for `PirAlgorithm == MulPir`