### PR TITLE
PIRProcessDatabase fix evaluation key size

### DIFF
--- a/Sources/PIRProcessDatabase/ProcessDatabase.swift
+++ b/Sources/PIRProcessDatabase/ProcessDatabase.swift
@@ -382,7 +382,7 @@ extension ProcessKeywordDatabase.ShardValidationResult {
         descriptionDict["query size"] = try sizeString(byteCount: query.size(), count: query.ciphertexts.count,
                                                        label: "ciphertexts")
         descriptionDict["evaluation key size"] = try sizeString(
-            byteCount: query.size(),
+            byteCount: evaluationKey.size(),
             count: evaluationKey.configuration.keyCount,
             label: "keys"
         )


### PR DESCRIPTION
I noticed from https://github.com/apple/swift-homomorphic-encryption/issues/45#issuecomment-2270463386, that the evaluation key size is wrong.