### PR TITLE
Reference HE articles manually

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -23,4 +23,3 @@ builder:
       - PIRGenerateDatabase
       - PIRProcessDatabase
       - PIRShardDatabase
-    - platform: linux

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Then, add the following dependency in your `Package.swift`
     url: "https://github.com/apple/swift-homomorphic-encryption",
     from: "tag"),
 ```
-, replacing `tag` with your chosen tag, e.g. `1.0.0-alpha.1`.
+, replacing `tag` with your chosen tag, e.g. `1.0.0-alpha.3`.
 
 To use the `HomomorphicEncryption` library, add
 ```swift

--- a/Sources/HomomorphicEncryption/HomomorphicEncryption.docc/HomomorphicEncryption.md
+++ b/Sources/HomomorphicEncryption/HomomorphicEncryption.docc/HomomorphicEncryption.md
@@ -34,3 +34,8 @@ This scheme can be configured to support post-quantum 128-bit security.
 > In particular, as little information as possible about each decrypted ciphertext should be sent back to the server. To protect against a malicious server, the client should also validate the decrypted content is in the expected format.
 >
 > Consult a cryptography expert when developing and deploying homomorphic encryption applications.
+
+## Articles
+
+- <doc:UsingSwiftHomomorphicEncryption>
+- <doc:DataFormats>

--- a/Sources/HomomorphicEncryption/HomomorphicEncryption.docc/UsingSwiftHomomorphicEncryption.md
+++ b/Sources/HomomorphicEncryption/HomomorphicEncryption.docc/UsingSwiftHomomorphicEncryption.md
@@ -18,7 +18,7 @@ Then, add the following dependency in your `Package.swift`
     url: "https://github.com/apple/swift-homomorphic-encryption",
     from: "tag"),
 ```
-replacing `tag` with your chosen tag, e.g. `1.0.0-alpha.1`.
+replacing `tag` with your chosen tag, e.g. `1.0.0-alpha.3`.
 
 To use the `HomomorphicEncryption` library, add
 ```swift


### PR DESCRIPTION
Snippets seem to interfere with generated docs:
https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption is missing the articles.
So until we figure out a root cause, we reference the articles manually.

Switching to Linux (https://github.com/apple/swift-homomorphic-encryption/pull/38) for docs didn't seem to change the [builds](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/builds), which still seem to use macOS (SPM) for docs.

Also, adopters can't actually depend on `1.0.0-alpha.1`, due to unsafe flags, which were removed in https://github.com/apple/swift-homomorphic-encryption/pull/14, which made it into `1.0.0-alpha.2`.