### PR TITLE
Implement PIR EvaluationKey compression

### DIFF
--- a/Benchmarks/PrivateInformationRetrievalBenchmark/PrivateInformationRetrievalBenchmark.swift
+++ b/Benchmarks/PrivateInformationRetrievalBenchmark/PrivateInformationRetrievalBenchmark.swift
@@ -109,6 +109,7 @@ func processBenchmark<Scheme: HeScheme>(_: Scheme.Type) -> () -> Void {
             polyDegree: 4096,
             plaintextModulusBits: 5,
             coefficientModulusBits: [27, 28, 28])
+        let keyCompression = PirKeyCompressionStrategy.noCompression
 
         let benchmarkName = [
             "Process",
@@ -116,6 +117,7 @@ func processBenchmark<Scheme: HeScheme>(_: Scheme.Type) -> () -> Void {
             encryptionConfig.description,
             "entryCount=\(entryCount)",
             "entrySize=\(entrySizeInBytes)",
+            "keyCompression=\(keyCompression)",
         ].joined(separator: "/")
         // swiftlint:disable closure_parameter_position
         Benchmark(benchmarkName, configuration: benchmarkConfiguration) { (
@@ -136,7 +138,8 @@ func processBenchmark<Scheme: HeScheme>(_: Scheme.Type) -> () -> Void {
                     entrySizeInBytes: entrySizeInBytes,
                     dimensionCount: 2,
                     batchSize: 1,
-                    unevenDimensions: true),
+                    unevenDimensions: true,
+                    keyCompression: keyCompression),
                 parameterConfig: encryptionConfig)
         }
         // swiftlint:enable closure_parameter_position
@@ -200,6 +203,7 @@ func indexPirBenchmark<Scheme: HeScheme>(_: Scheme.Type) -> () -> Void {
             polyDegree: 4096,
             plaintextModulusBits: 5,
             coefficientModulusBits: [27, 28, 28])
+        let keyCompression = PirKeyCompressionStrategy.noCompression
 
         let benchmarkName = [
             "IndexPir",
@@ -207,6 +211,7 @@ func indexPirBenchmark<Scheme: HeScheme>(_: Scheme.Type) -> () -> Void {
             encryptionConfig.description,
             "entryCount=\(entryCount)",
             "entrySize=\(entrySizeInBytes)",
+            "keyCompression=\(keyCompression)",
         ].joined(separator: "/")
         // swiftlint:disable closure_parameter_position
         Benchmark(benchmarkName, configuration: benchmarkConfiguration) { (
@@ -230,7 +235,8 @@ func indexPirBenchmark<Scheme: HeScheme>(_: Scheme.Type) -> () -> Void {
                     entrySizeInBytes: entrySizeInBytes,
                     dimensionCount: 2,
                     batchSize: 1,
-                    unevenDimensions: true),
+                    unevenDimensions: true,
+                    keyCompression: keyCompression),
                 parameterConfig: encryptionConfig)
         }
         // swiftlint:enable closure_parameter_position
@@ -256,7 +262,8 @@ struct KeywordPirBenchmarkContext<IndexServer: IndexPirServer, IndexClient: Inde
         dimensionCount: Int,
         databaseCount: Int,
         payloadSize: Int,
-        parameterConfig: EncryptionParametersConfig) throws
+        parameterConfig: EncryptionParametersConfig,
+        keyCompression: PirKeyCompressionStrategy) throws
     {
         let encryptParameter: EncryptionParameters<Server.Scheme> = try EncryptionParameters(from: parameterConfig)
         let context = try Context(encryptionParameters: encryptParameter)
@@ -270,7 +277,8 @@ struct KeywordPirBenchmarkContext<IndexServer: IndexPirServer, IndexClient: Inde
             dimensionCount: dimensionCount,
             cuckooTableConfig: CuckooTableConfig
                 .defaultKeywordPir(maxSerializedBucketSize: encryptParameter.bytesPerPlaintext),
-            unevenDimensions: true)
+            unevenDimensions: true,
+            keyCompression: keyCompression)
 
         let processed = try Server.process(database: rows,
                                            config: config,
@@ -315,6 +323,7 @@ func keywordPirBenchmark<Scheme: HeScheme>(_: Scheme.Type) -> () -> Void {
             polyDegree: 4096,
             plaintextModulusBits: 5,
             coefficientModulusBits: [27, 28, 28])
+        let keyCompression = PirKeyCompressionStrategy.noCompression
 
         let benchmarkName = [
             "KeywordPir",
@@ -322,6 +331,7 @@ func keywordPirBenchmark<Scheme: HeScheme>(_: Scheme.Type) -> () -> Void {
             encryptionConfig.description,
             "entryCount=\(entryCount)",
             "entrySize=\(entrySizeInBytes)",
+            "keyCompression=\(keyCompression)",
         ].joined(separator: "/")
         Benchmark(benchmarkName, configuration: benchmarkConfiguration) { benchmark, benchmarkContext in
             for _ in benchmark.scaledIterations {
@@ -337,7 +347,8 @@ func keywordPirBenchmark<Scheme: HeScheme>(_: Scheme.Type) -> () -> Void {
                 dimensionCount: 2,
                 databaseCount: entryCount,
                 payloadSize: entrySizeInBytes,
-                parameterConfig: encryptionConfig)
+                parameterConfig: encryptionConfig,
+                keyCompression: keyCompression)
         }
     }
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5b9484bfe90fcad029a55247c3e4766943d22ed6cccd872ea90c25339e5c2352",
+  "originHash" : "208d018145c06e7f81b20fe2b78f10d574541b40a9a1c01a3cb4f417b56c18b6",
   "pins" : [
     {
       "identity" : "hdrhistogram-swift",
@@ -17,15 +17,6 @@
       "state" : {
         "revision" : "6889229e21c6d9d0421a050e9e11c8f5eb5bc279",
         "version" : "1.23.5"
-      }
-    },
-    {
-      "identity" : "package-jemalloc",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/package-jemalloc",
-      "state" : {
-        "revision" : "e8a5db026963f5bfeac842d9d3f2cc8cde323b49",
-        "version" : "1.0.0"
       }
     },
     {

--- a/Sources/HomomorphicEncryption/Bfv/Bfv+Keys.swift
+++ b/Sources/HomomorphicEncryption/Bfv/Bfv+Keys.swift
@@ -34,7 +34,7 @@ extension Bfv {
             throw HeError.unsupportedHeOperation()
         }
         var galoisKeys: [Int: KeySwitchKey<Self>] = [:]
-        for element in configuration.galoisElements {
+        for element in configuration.galoisElements where !galoisKeys.keys.contains(element) {
             let switchedKey = try secretKey.poly.applyGalois(element: element)
             galoisKeys[element] = try generateKeySwitchKey(
                 context: context,

--- a/Sources/HomomorphicEncryption/Keys.swift
+++ b/Sources/HomomorphicEncryption/Keys.swift
@@ -140,7 +140,7 @@ public struct EvaluationKey<Scheme: HeScheme>: Equatable, Sendable {
 }
 
 /// A configuration for generating an evaluation key.
-public struct EvaluationKeyConfiguration: Equatable, Sendable {
+public struct EvaluationKeyConfiguration: Codable, Equatable, Hashable, Sendable {
     /// Galois elements.
     /// - seealso: ``GaloisElement``and ``HeScheme/applyGalois(ciphertext:element:using:)`` for more information.
     public let galoisElements: [Int]

--- a/Sources/HomomorphicEncryption/NoOpScheme.swift
+++ b/Sources/HomomorphicEncryption/NoOpScheme.swift
@@ -35,11 +35,15 @@ public enum NoOpScheme: HeScheme {
 
     public static func generateEvaluationKey(
         context: Context<NoOpScheme>,
-        configuration _: EvaluationKeyConfiguration, using _: SecretKey<NoOpScheme>) throws -> EvaluationKey<NoOpScheme>
+        configuration: EvaluationKeyConfiguration, using _: SecretKey<NoOpScheme>) throws -> EvaluationKey<NoOpScheme>
     {
-        EvaluationKey(
-            galoisKey: GaloisKey(keys: [:]),
-            relinearizationKey: RelinearizationKey(keySwitchKey: KeySwitchKey(context: context, ciphers: [])))
+        let keySwitchKey = KeySwitchKey(context: context, ciphers: [])
+        let galoisKeys = [Int: KeySwitchKey<NoOpScheme>](
+            configuration.galoisElements
+                .map { g in (g, keySwitchKey) }) { first, _ in first }
+        return EvaluationKey(
+            galoisKey: GaloisKey(keys: galoisKeys),
+            relinearizationKey: RelinearizationKey(keySwitchKey: keySwitchKey))
     }
 
     public static func encode(context: Context<NoOpScheme>, values: [some ScalarType],

--- a/Sources/PIRProcessDatabase/PIRProcessDatabase.docc/PIRProcessDatabase.md
+++ b/Sources/PIRProcessDatabase/PIRProcessDatabase.docc/PIRProcessDatabase.md
@@ -116,6 +116,8 @@ The suggested value is 1.
 The `outputEvaluationKeyConfig` argument will store a configuration that is
 suitable for any of the processed shards.
 
+* `keyCompression`. The evaluation key can be made smaller at the cost of extra server runtime. For fastest runtime, leave unspecified. For smallest key size, choose `maxCompression`. For a middle ground, choose `hybridCompression`.
+
 #### Cuckoo Table Parameters
 Keyword PIR uses bucketed cuckoo hashing to map a keyword to an index in the
 database/shard which stores a bucket of keywords’ metadata. All cuckoo table

--- a/Sources/PrivateInformationRetrieval/KeywordDatabase.swift
+++ b/Sources/PrivateInformationRetrieval/KeywordDatabase.swift
@@ -271,6 +271,8 @@ public enum ProcessKeywordDatabase {
         public let encryptionParameters: EncryptionParameters<Scheme>
         /// PIR algorithm to process with.
         public let algorithm: PirAlgorithm
+        /// Strategy for ``EvaluationKey`` compression.
+        public let keyCompression: PirKeyCompressionStrategy
         /// Number of test queries per shard.
         public let trialsPerShard: Int
 
@@ -279,12 +281,14 @@ public enum ProcessKeywordDatabase {
         ///   - databaseConfig: Database configuration.
         ///   - encryptionParameters: Encryption parameters.
         ///   - algorithm: PIR algorithm to process with.
-        ///   - trialsPerShard: number of test queries per shard.
+        ///   - keyCompression: Strategy for ``EvaluationKey`` compression.
+        ///   - trialsPerShard: Number of test queries per shard.
         ///  - Throws: Error upon invalid arguments
         public init(
             databaseConfig: KeywordDatabaseConfig,
             encryptionParameters: EncryptionParameters<Scheme>,
             algorithm: PirAlgorithm,
+            keyCompression: PirKeyCompressionStrategy,
             trialsPerShard: Int) throws
         {
             guard trialsPerShard >= 0 else {
@@ -296,6 +300,7 @@ public enum ProcessKeywordDatabase {
             self.databaseConfig = databaseConfig
             self.encryptionParameters = encryptionParameters
             self.algorithm = algorithm
+            self.keyCompression = keyCompression
             self.trialsPerShard = trialsPerShard
         }
     }
@@ -474,12 +479,8 @@ public enum ProcessKeywordDatabase {
             let processed = try KeywordPirServer<MulPirServer<Scheme>>.process(database: shardedDatabase,
                                                                                config: keywordConfig,
                                                                                with: context)
-            evaluationKeyConfiguration = [
-                evaluationKeyConfiguration,
-                MulPir.evaluationKeyConfiguration(
-                    parameter: processed.pirParameter,
-                    encryptionParameters: arguments.encryptionParameters),
-            ].union()
+            evaluationKeyConfiguration = [evaluationKeyConfiguration, processed.pirParameter.evaluationKeyConfig]
+                .union()
 
             processedShards[shardID] = processed
         }

--- a/Sources/PrivateInformationRetrievalProtobuf/ConversionApi.swift
+++ b/Sources/PrivateInformationRetrievalProtobuf/ConversionApi.swift
@@ -46,14 +46,17 @@ extension Response {
 
 extension Apple_SwiftHomomorphicEncryption_Api_V1_PIRShardConfig {
     /// Converts the protobuf object to a native type.
-    /// - Parameter batchSize: Number of queries in a batch.
-    /// - Returns: The converted protobuf object.
-    public func native(batchSize: Int) -> IndexPirParameter {
+    /// - Parameters:
+    ///   - batchSize: Number of queries in a batch.
+    ///   - evaluationKeyConfig: Evaluation key configuration
+    /// - Returns: The converted native type.
+    public func native(batchSize: Int, evaluationKeyConfig: EvaluationKeyConfiguration) -> IndexPirParameter {
         IndexPirParameter(
             entryCount: Int(numEntries),
             entrySizeInBytes: Int(entrySize),
             dimensions: dimensions.map(Int.init),
-            batchSize: batchSize)
+            batchSize: batchSize,
+            evaluationKeyConfig: evaluationKeyConfig)
     }
 }
 

--- a/Sources/PrivateInformationRetrievalProtobuf/ConversionPir.swift
+++ b/Sources/PrivateInformationRetrievalProtobuf/ConversionPir.swift
@@ -95,7 +95,8 @@ extension Apple_SwiftHomomorphicEncryption_Pir_V1_PirParameters {
             entryCount: Int(numEntries),
             entrySizeInBytes: Int(entrySize),
             dimensions: dimensions.map(Int.init),
-            batchSize: Int(batchSize))
+            batchSize: Int(batchSize),
+            evaluationKeyConfig: evaluationKeyConfig.native())
     }
 
     /// Converts the protobuf object into a native type.
@@ -134,6 +135,32 @@ extension PirAlgorithm {
         switch self {
         case .aclsPir: Apple_SwiftHomomorphicEncryption_Pir_V1_PirAlgorithm.aclsPir
         case .mulPir: Apple_SwiftHomomorphicEncryption_Pir_V1_PirAlgorithm.mulPir
+        }
+    }
+}
+
+extension Apple_SwiftHomomorphicEncryption_Pir_V1_KeyCompressionStrategy {
+    /// Converts the protobuf object to a native type.
+    /// - Returns: The converted native type.
+    public func native() throws -> PirKeyCompressionStrategy {
+        switch self {
+        case .unspecified: PirKeyCompressionStrategy.noCompression
+        case .hybridCompression: PirKeyCompressionStrategy.hybridCompression
+        case .maximumCompression: PirKeyCompressionStrategy.maxCompression
+        case let .UNRECOGNIZED(value):
+            throw ConversionError.unrecognizedEnumValue(enum: Self.self, value: value)
+        }
+    }
+}
+
+extension PirKeyCompressionStrategy {
+    /// Converts the native object into a protobuf object.
+    /// - Returns: The converted protobuf object.
+    public func proto() -> Apple_SwiftHomomorphicEncryption_Pir_V1_KeyCompressionStrategy {
+        switch self {
+        case .noCompression: Apple_SwiftHomomorphicEncryption_Pir_V1_KeyCompressionStrategy.unspecified
+        case .hybridCompression: Apple_SwiftHomomorphicEncryption_Pir_V1_KeyCompressionStrategy.hybridCompression
+        case .maxCompression: Apple_SwiftHomomorphicEncryption_Pir_V1_KeyCompressionStrategy.maximumCompression
         }
     }
 }

--- a/Tests/PrivateInformationRetrievalProtobufTests/ConversionTests.swift
+++ b/Tests/PrivateInformationRetrievalProtobufTests/ConversionTests.swift
@@ -42,7 +42,8 @@ class ConversionTests: XCTestCase {
         let config = try KeywordPirConfig(
             dimensionCount: 2,
             cuckooTableConfig: .defaultKeywordPir(maxSerializedBucketSize: context.bytesPerPlaintext),
-            unevenDimensions: true)
+            unevenDimensions: true,
+            keyCompression: .noCompression)
         let processedDatabaseWithParameters = try KeywordPirServer<MulPirServer<Bfv<UInt32>>>.process(
             database: rows,
             config: config,
@@ -53,5 +54,17 @@ class ConversionTests: XCTestCase {
         let pirParameters = try processedDatabaseWithParameters.proto(context: context)
         let loadedProcessedDatabaseWithParameters = try pirParameters.native(database: processedDatabase)
         XCTAssertEqual(loadedProcessedDatabaseWithParameters, processedDatabaseWithParameters)
+    }
+
+    func testPirAlgorithm() throws {
+        for algorithm in PirAlgorithm.allCases {
+            XCTAssertEqual(try algorithm.proto().native(), algorithm)
+        }
+    }
+
+    func testPirKeyCompressionStrategy() throws {
+        for strategy in PirKeyCompressionStrategy.allCases {
+            XCTAssertEqual(try strategy.proto().native(), strategy)
+        }
     }
 }

--- a/Tests/PrivateInformationRetrievalTests/IndexPirTests.swift
+++ b/Tests/PrivateInformationRetrievalTests/IndexPirTests.swift
@@ -26,7 +26,8 @@ class IndexPirTests: XCTestCase {
                                             entrySizeInBytes: context.bytesPerPlaintext,
                                             dimensionCount: 2,
                                             batchSize: 1,
-                                            unevenDimensions: false)
+                                            unevenDimensions: false,
+                                            keyCompression: .noCompression)
             let parameter = MulPir.generateParameter(config: config, with: context)
             XCTAssertEqual(parameter.dimensions, [4, 4])
         }
@@ -35,7 +36,8 @@ class IndexPirTests: XCTestCase {
                                             entrySizeInBytes: context.bytesPerPlaintext,
                                             dimensionCount: 2,
                                             batchSize: 2,
-                                            unevenDimensions: false)
+                                            unevenDimensions: false,
+                                            keyCompression: .noCompression)
             let parameter = MulPir.generateParameter(config: config, with: context)
             XCTAssertEqual(parameter.dimensions, [4, 3])
         }
@@ -45,7 +47,8 @@ class IndexPirTests: XCTestCase {
                                             entrySizeInBytes: context.bytesPerPlaintext,
                                             dimensionCount: 2,
                                             batchSize: 1,
-                                            unevenDimensions: true)
+                                            unevenDimensions: true,
+                                            keyCompression: .noCompression)
             let parameter = MulPir.generateParameter(config: config, with: context)
             XCTAssertEqual(parameter.dimensions, [5, 3])
         }
@@ -54,7 +57,8 @@ class IndexPirTests: XCTestCase {
                                             entrySizeInBytes: context.bytesPerPlaintext,
                                             dimensionCount: 2,
                                             batchSize: 2,
-                                            unevenDimensions: true)
+                                            unevenDimensions: true,
+                                            keyCompression: .noCompression)
             let parameter = MulPir.generateParameter(config: config, with: context)
             XCTAssertEqual(parameter.dimensions, [5, 3])
         }
@@ -63,9 +67,52 @@ class IndexPirTests: XCTestCase {
                                             entrySizeInBytes: context.bytesPerPlaintext,
                                             dimensionCount: 2,
                                             batchSize: 2,
-                                            unevenDimensions: true)
+                                            unevenDimensions: true,
+                                            keyCompression: .noCompression)
             let parameter = MulPir.generateParameter(config: config, with: context)
             XCTAssertEqual(parameter.dimensions, [9, 2])
+        }
+        // no key compression
+        do {
+            let config = try IndexPirConfig(entryCount: 100,
+                                            entrySizeInBytes: context.bytesPerPlaintext,
+                                            dimensionCount: 2,
+                                            batchSize: 2,
+                                            unevenDimensions: true,
+                                            keyCompression: .noCompression)
+            let parameter = MulPir.generateParameter(config: config, with: context)
+            let evalKeyConfig = EvaluationKeyConfiguration(
+                galoisElements: [3, 5, 9, 17],
+                hasRelinearizationKey: true)
+            XCTAssertEqual(parameter.evaluationKeyConfig, evalKeyConfig)
+        }
+        // hybrid key compression
+        do {
+            let config = try IndexPirConfig(entryCount: 100,
+                                            entrySizeInBytes: context.bytesPerPlaintext,
+                                            dimensionCount: 2,
+                                            batchSize: 2,
+                                            unevenDimensions: true,
+                                            keyCompression: .hybridCompression)
+            let parameter = MulPir.generateParameter(config: config, with: context)
+            let evalKeyConfig = EvaluationKeyConfiguration(
+                galoisElements: [3, 5, 9, 17],
+                hasRelinearizationKey: true)
+            XCTAssertEqual(parameter.evaluationKeyConfig, evalKeyConfig)
+        }
+        // max key compression
+        do {
+            let config = try IndexPirConfig(entryCount: 100,
+                                            entrySizeInBytes: context.bytesPerPlaintext,
+                                            dimensionCount: 2,
+                                            batchSize: 2,
+                                            unevenDimensions: true,
+                                            keyCompression: .maxCompression)
+            let parameter = MulPir.generateParameter(config: config, with: context)
+            let evalKeyConfig = EvaluationKeyConfiguration(
+                galoisElements: [3, 5, 9],
+                hasRelinearizationKey: true)
+            XCTAssertEqual(parameter.evaluationKeyConfig, evalKeyConfig)
         }
     }
 
@@ -116,39 +163,50 @@ class IndexPirTests: XCTestCase {
                                                                               client: Client.Type) throws
         where Server.IndexPir == Client.IndexPir
     {
-        let config1 = try IndexPirConfig(entryCount: 100,
-                                         entrySizeInBytes: 1,
-                                         dimensionCount: 2,
-                                         batchSize: 2,
-                                         unevenDimensions: false)
-        let config2 = try IndexPirConfig(entryCount: 100,
-                                         entrySizeInBytes: 8,
-                                         dimensionCount: 2,
-                                         batchSize: 2,
-                                         unevenDimensions: false)
-        let config3 = try IndexPirConfig(entryCount: 100,
-                                         entrySizeInBytes: 24,
-                                         dimensionCount: 2,
-                                         batchSize: 2,
-                                         unevenDimensions: true)
-        let config4 = try IndexPirConfig(entryCount: 100,
-                                         entrySizeInBytes: 24,
-                                         dimensionCount: 1,
-                                         batchSize: 2,
-                                         unevenDimensions: true)
+        let configs = try [
+            IndexPirConfig(entryCount: 100,
+                           entrySizeInBytes: 1,
+                           dimensionCount: 2,
+                           batchSize: 2,
+                           unevenDimensions: false,
+                           keyCompression: .noCompression),
+            IndexPirConfig(entryCount: 100,
+                           entrySizeInBytes: 8,
+                           dimensionCount: 2,
+                           batchSize: 2,
+                           unevenDimensions: false,
+                           keyCompression: .noCompression),
+            IndexPirConfig(entryCount: 100,
+                           entrySizeInBytes: 24,
+                           dimensionCount: 2,
+                           batchSize: 2,
+                           unevenDimensions: true,
+                           keyCompression: .noCompression),
+            IndexPirConfig(entryCount: 100,
+                           entrySizeInBytes: 24,
+                           dimensionCount: 1,
+                           batchSize: 2,
+                           unevenDimensions: true,
+                           keyCompression: .noCompression),
+            IndexPirConfig(entryCount: 100,
+                           entrySizeInBytes: 24,
+                           dimensionCount: 1,
+                           batchSize: 2,
+                           unevenDimensions: true,
+                           keyCompression: .hybridCompression),
+            IndexPirConfig(entryCount: 100,
+                           entrySizeInBytes: 24,
+                           dimensionCount: 1,
+                           batchSize: 2,
+                           unevenDimensions: true,
+                           keyCompression: .maxCompression),
+        ]
 
         let context: Context<Server.Scheme> = try TestUtils.getTestContext()
-        let parameter1 = Server.generateParameter(config: config1, with: context)
-        try indexPirTestForParameter(server: server, client: client, for: parameter1, with: context)
-
-        let parameter2 = Server.generateParameter(config: config2, with: context)
-        try indexPirTestForParameter(server: server, client: client, for: parameter2, with: context)
-
-        let parameter3 = Server.generateParameter(config: config3, with: context)
-        try indexPirTestForParameter(server: server, client: client, for: parameter3, with: context)
-
-        let parameter4 = Server.generateParameter(config: config4, with: context)
-        try indexPirTestForParameter(server: server, client: client, for: parameter4, with: context)
+        for config in configs {
+            let parameter = Server.generateParameter(config: config, with: context)
+            try indexPirTestForParameter(server: server, client: client, for: parameter, with: context)
+        }
     }
 
     private func mulIndexPirTest<Scheme: HeScheme>(scheme _: Scheme.Type) throws {

--- a/Tests/PrivateInformationRetrievalTests/KeywordPirTests.swift
+++ b/Tests/PrivateInformationRetrievalTests/KeywordPirTests.swift
@@ -39,7 +39,8 @@ class KeywordPirTests: XCTestCase {
             let keywordConfig = try KeywordPirConfig(
                 dimensionCount: 2,
                 cuckooTableConfig: PirTestUtils.testCuckooTableConfig(maxSerializedBucketSize: 5 * valueSize),
-                unevenDimensions: true)
+                unevenDimensions: true,
+                keyCompression: .noCompression)
             let processed = try KeywordPirServer<PirServer>.process(database: testDatabase,
                                                                     config: keywordConfig,
                                                                     with: testContext)
@@ -109,7 +110,8 @@ class KeywordPirTests: XCTestCase {
         let keywordConfig = try KeywordPirConfig(
             dimensionCount: 2,
             cuckooTableConfig: cuckooTableConfig,
-            unevenDimensions: true)
+            unevenDimensions: true,
+            keyCompression: .noCompression)
         try KeywordPirTest(
             encryptionParameters: TestUtils.getTestEncryptionParameters(),
             keywordConfig: keywordConfig,
@@ -136,7 +138,7 @@ class KeywordPirTests: XCTestCase {
         let keywordConfig = try KeywordPirConfig(
             dimensionCount: 2,
             cuckooTableConfig: cuckooTableConfig,
-            unevenDimensions: true)
+            unevenDimensions: true, keyCompression: .noCompression)
         try KeywordPirTest(
             encryptionParameters: TestUtils.getTestEncryptionParameters(),
             keywordConfig: keywordConfig,
@@ -159,7 +161,7 @@ class KeywordPirTests: XCTestCase {
             dimensionCount: 1,
             cuckooTableConfig: PirTestUtils.testCuckooTableConfig(
                 maxSerializedBucketSize: 100),
-            unevenDimensions: true)
+            unevenDimensions: true, keyCompression: .noCompression)
         try KeywordPirTest(
             encryptionParameters: TestUtils.getTestEncryptionParameters(),
             keywordConfig: keywordConfig,
@@ -182,7 +184,53 @@ class KeywordPirTests: XCTestCase {
             dimensionCount: 2,
             cuckooTableConfig: PirTestUtils.testCuckooTableConfig(
                 maxSerializedBucketSize: 100),
-            unevenDimensions: true)
+            unevenDimensions: true, keyCompression: .noCompression)
+        try KeywordPirTest(
+            encryptionParameters: TestUtils.getTestEncryptionParameters(),
+            keywordConfig: keywordConfig,
+            server: MulPirServer<NoOpScheme>.self,
+            client: MulPirClient<NoOpScheme>.self)
+        try KeywordPirTest(
+            encryptionParameters: TestUtils.getTestEncryptionParameters(),
+            keywordConfig: keywordConfig,
+            server: MulPirServer<Bfv<UInt32>>.self,
+            client: MulPirClient<Bfv<UInt32>>.self)
+        try KeywordPirTest(
+            encryptionParameters: TestUtils.getTestEncryptionParameters(),
+            keywordConfig: keywordConfig,
+            server: MulPirServer<Bfv<UInt64>>.self,
+            client: MulPirClient<Bfv<UInt64>>.self)
+    }
+
+    func testKeywordPirMulPirHybridKeyCompression() throws {
+        let keywordConfig = try KeywordPirConfig(
+            dimensionCount: 2,
+            cuckooTableConfig: PirTestUtils.testCuckooTableConfig(
+                maxSerializedBucketSize: 100),
+            unevenDimensions: true, keyCompression: .hybridCompression)
+        try KeywordPirTest(
+            encryptionParameters: TestUtils.getTestEncryptionParameters(),
+            keywordConfig: keywordConfig,
+            server: MulPirServer<NoOpScheme>.self,
+            client: MulPirClient<NoOpScheme>.self)
+        try KeywordPirTest(
+            encryptionParameters: TestUtils.getTestEncryptionParameters(),
+            keywordConfig: keywordConfig,
+            server: MulPirServer<Bfv<UInt32>>.self,
+            client: MulPirClient<Bfv<UInt32>>.self)
+        try KeywordPirTest(
+            encryptionParameters: TestUtils.getTestEncryptionParameters(),
+            keywordConfig: keywordConfig,
+            server: MulPirServer<Bfv<UInt64>>.self,
+            client: MulPirClient<Bfv<UInt64>>.self)
+    }
+
+    func testKeywordPirMulPirMaxKeyCompression() throws {
+        let keywordConfig = try KeywordPirConfig(
+            dimensionCount: 2,
+            cuckooTableConfig: PirTestUtils.testCuckooTableConfig(
+                maxSerializedBucketSize: 100),
+            unevenDimensions: true, keyCompression: .maxCompression)
         try KeywordPirTest(
             encryptionParameters: TestUtils.getTestEncryptionParameters(),
             keywordConfig: keywordConfig,
@@ -208,7 +256,7 @@ class KeywordPirTests: XCTestCase {
                 dimensionCount: 2,
                 cuckooTableConfig: PirTestUtils.testCuckooTableConfig(
                     maxSerializedBucketSize: 3 * noOpParameters.bytesPerPlaintext),
-                unevenDimensions: true)
+                unevenDimensions: true, keyCompression: .noCompression)
             try KeywordPirTest(
                 encryptionParameters: noOpParameters,
                 keywordConfig: keywordConfig,
@@ -222,7 +270,7 @@ class KeywordPirTests: XCTestCase {
                 dimensionCount: 2,
                 cuckooTableConfig: PirTestUtils.testCuckooTableConfig(
                     maxSerializedBucketSize: 3 * bfv32Parameters.bytesPerPlaintext),
-                unevenDimensions: true)
+                unevenDimensions: true, keyCompression: .noCompression)
             try KeywordPirTest(
                 encryptionParameters: bfv32Parameters,
                 keywordConfig: keywordConfig,
@@ -236,7 +284,7 @@ class KeywordPirTests: XCTestCase {
                 dimensionCount: 2,
                 cuckooTableConfig: PirTestUtils.testCuckooTableConfig(
                     maxSerializedBucketSize: 3 * bfv64Parameters.bytesPerPlaintext),
-                unevenDimensions: true)
+                unevenDimensions: true, keyCompression: .noCompression)
             try KeywordPirTest(
                 encryptionParameters: bfv64Parameters,
                 keywordConfig: keywordConfig,
@@ -265,7 +313,7 @@ class KeywordPirTests: XCTestCase {
                 let keywordConfig = try KeywordPirConfig(
                     dimensionCount: 2,
                     cuckooTableConfig: cuckooConfig,
-                    unevenDimensions: true)
+                    unevenDimensions: true, keyCompression: .noCompression)
                 let testDatabase = PirTestUtils.getTestTable(rowCount: rowCount, valueSize: valueSize, using: &rng)
                 let processed = try KeywordPirServer<PirServer>.process(database: testDatabase,
                                                                         config: keywordConfig,
@@ -276,7 +324,7 @@ class KeywordPirTests: XCTestCase {
                         .freezingTableSize(
                             maxSerializedBucketSize: processed.pirParameter.entrySizeInBytes,
                             bucketCount: processed.pirParameter.entryCount * processed.pirParameter.batchSize),
-                    unevenDimensions: true)
+                    unevenDimensions: true, keyCompression: .noCompression)
                 return (processed.pirParameter, newConfig)
             }()
 
@@ -333,7 +381,7 @@ class KeywordPirTests: XCTestCase {
             let config = try KeywordPirConfig(
                 dimensionCount: 2,
                 cuckooTableConfig: .defaultKeywordPir(maxSerializedBucketSize: 1024),
-                unevenDimensions: true)
+                unevenDimensions: true, keyCompression: .noCompression)
             let processed = try KeywordPirServer<PirServer>.process(
                 database: testDatabase,
                 config: config,
@@ -368,7 +416,7 @@ class KeywordPirTests: XCTestCase {
         let keywordConfig = try KeywordPirConfig(
             dimensionCount: 2,
             cuckooTableConfig: cuckooConfig,
-            unevenDimensions: true)
+            unevenDimensions: true, keyCompression: .noCompression)
         let databaseConfig = KeywordDatabaseConfig(
             sharding: Sharding.shardCount(1),
             keywordPirConfig: keywordConfig)
@@ -377,7 +425,7 @@ class KeywordPirTests: XCTestCase {
         XCTAssertThrowsError(try ProcessKeywordDatabase.Arguments(
             databaseConfig: databaseConfig,
             encryptionParameters: encryptionParameters,
-            algorithm: PirAlgorithm.aclsPir,
+            algorithm: PirAlgorithm.aclsPir, keyCompression: .noCompression,
             trialsPerShard: 1),
         error: PirError.invalidPirAlgorithm(PirAlgorithm.aclsPir))
     }
@@ -403,7 +451,7 @@ class KeywordPirTests: XCTestCase {
             let keywordConfig = try KeywordPirConfig(
                 dimensionCount: 2,
                 cuckooTableConfig: cuckooConfig,
-                unevenDimensions: true)
+                unevenDimensions: true, keyCompression: .noCompression)
             let databaseConfig = KeywordDatabaseConfig(
                 sharding: Sharding.shardCount(shardCount),
                 keywordPirConfig: keywordConfig)
@@ -412,7 +460,7 @@ class KeywordPirTests: XCTestCase {
             let args = try ProcessKeywordDatabase.Arguments(
                 databaseConfig: databaseConfig,
                 encryptionParameters: encryptionParameters,
-                algorithm: PirAlgorithm.mulPir,
+                algorithm: PirAlgorithm.mulPir, keyCompression: .noCompression,
                 trialsPerShard: 1)
             let processed: ProcessKeywordDatabase.Processed<PirServer.Scheme> = try ProcessKeywordDatabase.process(
                 rows: testDatabase,

--- a/Tests/PrivateInformationRetrievalTests/PirTestUtils.swift
+++ b/Tests/PrivateInformationRetrievalTests/PirTestUtils.swift
@@ -33,6 +33,7 @@ package enum PirTestUtils {
         with context: Context<PIR.Scheme>,
         entryCount: Int,
         entrySizeInBytes: Int,
+        keyCompression: PirKeyCompressionStrategy,
         batchSize: Int = 10) throws -> IndexPirParameter
     {
         let config = try IndexPirConfig(
@@ -40,7 +41,8 @@ package enum PirTestUtils {
             entrySizeInBytes: entrySizeInBytes,
             dimensionCount: 2,
             batchSize: batchSize,
-            unevenDimensions: true)
+            unevenDimensions: true,
+            keyCompression: keyCompression)
         return PIR.generateParameter(config: config, with: context)
     }
 


### PR DESCRIPTION
KeywordPIR benchmarks show (when manually changing the compression & recompiling):

NoCompression
```
KeywordPir/Bfv<UInt64>/N=4096/logt=5/logq=[27, 28, 28]/entryCount=10000/entrySize=100/keyCompression=noCompression
╒═════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Metric                          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Evaluation key byte size (K) *  │     681 │     681 │     681 │     681 │     681 │     681 │     681 │      56 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Malloc (total) *                │       0 │       0 │       0 │       0 │       0 │       0 │       0 │      56 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Memory (resident peak) (M)      │     141 │     213 │     225 │     247 │     258 │     268 │     268 │      56 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Noise budget x 10 *             │     112 │     112 │     112 │     112 │     112 │     112 │     112 │      56 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Query byte size (K) *           │      28 │      28 │      28 │      28 │      28 │      28 │      28 │      56 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Response byte size (K) *        │      25 │      25 │      25 │      25 │      25 │      25 │      25 │      56 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (wall clock) (ms) *        │      83 │      87 │      88 │      92 │      96 │     100 │     100 │      56 │
╘═════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```

HybridCompression:
```
KeywordPir/Bfv<UInt64>/N=4096/logt=5/logq=[27, 28, 28]/entryCount=10000/entrySize=100/keyCompression=hybridCompression
╒═════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Metric                          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Evaluation key byte size (K) *  │     340 │     340 │     340 │     340 │     340 │     340 │     340 │      47 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Malloc (total) *                │       0 │       0 │       0 │       0 │       0 │       0 │       0 │      47 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Memory (resident peak) (M)      │     147 │     220 │     226 │     234 │     234 │     234 │     234 │      47 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Noise budget x 10 *             │      97 │      97 │      97 │      97 │      97 │      97 │      97 │      47 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Query byte size (K) *           │      28 │      28 │      28 │      28 │      28 │      28 │      28 │      47 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Response byte size (K) *        │      25 │      25 │      25 │      25 │      25 │      25 │      25 │      47 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (wall clock) (ms) *        │     101 │     103 │     107 │     111 │     114 │     120 │     120 │      47 │
╘═════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```

MaxCompression:
```
KeywordPir/Bfv<UInt64>/N=4096/logt=5/logq=[27, 28, 28]/entryCount=10000/entrySize=100/keyCompression=maxCompression
╒═════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Metric                          │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Evaluation key byte size (K) *  │     255 │     255 │     255 │     255 │     255 │     255 │     255 │      35 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Malloc (total) *                │       0 │       0 │       0 │       0 │       0 │       0 │       0 │      35 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Memory (resident peak) (M)      │     147 │     185 │     207 │     233 │     233 │     233 │     233 │      35 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Noise budget x 10 *             │      85 │      85 │      85 │      85 │      85 │      85 │      85 │      35 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Query byte size (K) *           │      28 │      28 │      28 │      28 │      28 │      28 │      28 │      35 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Response byte size (K) *        │      25 │      25 │      25 │      25 │      25 │      25 │      25 │      35 │
├─────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (wall clock) (ms) *        │     132 │     139 │     143 │     147 │     150 │     157 │     157 │      35 │
╘═════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```