### PR TITLE
Fix NoOp scheme context.encode/decode API

### DIFF
--- a/Benchmarks/RlweBenchmark/RlweBenchmark.swift
+++ b/Benchmarks/RlweBenchmark/RlweBenchmark.swift
@@ -85,7 +85,7 @@ struct RlweBenchmarkContext<Scheme: HeScheme>: Sendable {
         self.serializedEvaluationKey = evaluationKey.serialize()
 
         self.data = getRandomPlaintextData(count: polyDegree, in: 0..<Scheme.Scalar(plaintextModulus))
-        self.coeffPlaintext = try Scheme.encode(context: context, values: data, format: .simd)
+        self.coeffPlaintext = try context.encode(values: data, format: .simd)
         self.evalPlaintext = try coeffPlaintext.convertToEvalFormat()
         self.ciphertext = try coeffPlaintext.encrypt(using: secretKey)
         self.evalCiphertext = try ciphertext.convertToEvalFormat()
@@ -123,9 +123,8 @@ func encodeCoefficientBenchmark<Scheme: HeScheme>(_: Scheme.Type) -> () -> Void 
             benchmark.startMeasurement()
             var plaintext: Scheme.CoeffPlaintext?
             for _ in benchmark.scaledIterations {
-                try blackHole(plaintext = Scheme.encode(context: benchmarkContext.context,
-                                                        values: benchmarkContext.data,
-                                                        format: .coefficient))
+                try blackHole(plaintext = benchmarkContext.context.encode(values: benchmarkContext.data,
+                                                                          format: .coefficient))
             }
             // Avoid warning about variable written to, but never read
             withExtendedLifetime(plaintext) {}
@@ -140,9 +139,8 @@ func encodeSimdBenchmark<Scheme: HeScheme>(_: Scheme.Type) -> () -> Void {
             benchmark.startMeasurement()
             var plaintext: Scheme.CoeffPlaintext?
             for _ in benchmark.scaledIterations {
-                try blackHole(plaintext = Scheme.encode(context: benchmarkContext.context,
-                                                        values: benchmarkContext.data,
-                                                        format: .simd))
+                try blackHole(plaintext = benchmarkContext.context.encode(values: benchmarkContext.data,
+                                                                          format: .simd))
             }
             // Avoid warning about variable written to, but never read
             withExtendedLifetime(plaintext) {}

--- a/Snippets/HomomorphicEncryption/SerializationSnippet.swift
+++ b/Snippets/HomomorphicEncryption/SerializationSnippet.swift
@@ -127,7 +127,7 @@ deserialized = try Ciphertext(
     context: context,
     moduliCount: 1)
 let decryptedIndices = try deserialized.decrypt(using: secretKey)
-let clientDecoded = try decryptedIndices.decode(format: .coefficient)
+let clientDecoded: [UInt32] = try decryptedIndices.decode(format: .coefficient)
 for index in indices {
     precondition(clientDecoded[index] == expectedValues[index])
 }

--- a/Sources/HomomorphicEncryption/Bfv/Bfv+Encode.swift
+++ b/Sources/HomomorphicEncryption/Bfv/Bfv+Encode.swift
@@ -24,28 +24,22 @@ extension Bfv {
     @inlinable
     // swiftlint:disable:next missing_docs attributes
     public static func encode(context: Context<Bfv<T>>, values: [some ScalarType], format: EncodeFormat,
-                              moduliCount: Int) throws -> EvalPlaintext
+                              moduliCount: Int?) throws -> EvalPlaintext
     {
-        try context.encode(values: values, format: format, moduliCount: moduliCount)
+        let coeffPlaintext = try Self.encode(context: context, values: values, format: format)
+        return try coeffPlaintext.convertToEvalFormat(moduliCount: moduliCount)
     }
 
     @inlinable
     // swiftlint:disable:next missing_docs attributes
-    public static func encode(context: Context<Bfv<T>>, values: [some ScalarType],
-                              format: EncodeFormat) throws -> EvalPlaintext
-    {
-        try context.encode(values: values, format: format, moduliCount: nil)
-    }
-
-    @inlinable
-    // swiftlint:disable:next missing_docs attributes
-    public static func decode<V>(plaintext: CoeffPlaintext, format: EncodeFormat) throws -> [V] where V: ScalarType {
+    public static func decode<V: ScalarType>(plaintext: CoeffPlaintext, format: EncodeFormat) throws -> [V] {
         try plaintext.context.decode(plaintext: plaintext, format: format)
     }
 
     @inlinable
     // swiftlint:disable:next missing_docs attributes
-    public static func decode<V>(plaintext: EvalPlaintext, format: EncodeFormat) throws -> [V] where V: ScalarType {
-        try plaintext.context.decode(plaintext: plaintext, format: format)
+    public static func decode<V: ScalarType>(plaintext: EvalPlaintext, format: EncodeFormat) throws -> [V] {
+        let coeffPlaintext = try plaintext.convertToCoeffFormat()
+        return try coeffPlaintext.decode(format: format)
     }
 }

--- a/Sources/HomomorphicEncryption/Context.swift
+++ b/Sources/HomomorphicEncryption/Context.swift
@@ -39,7 +39,7 @@ public final class Context<Scheme: HeScheme>: Equatable, Sendable {
     /// `keySwitchingContexts[0].next.moduli = [q_0, q_1]`
     @usableFromInline let keySwitchingContexts: [PolyContext<Scheme.Scalar>]
 
-    /// the rns tools for each level of ciphertexts, with number of modulis in descending order.
+    /// The rns tools for each level of ciphertexts, with number of moduli in descending order.
     @usableFromInline let rnsTools: [RnsTool<Scheme.Scalar>]
 
     /// The plaintext modulus,`t`.

--- a/Sources/HomomorphicEncryption/Encoding.swift
+++ b/Sources/HomomorphicEncryption/Encoding.swift
@@ -17,72 +17,6 @@
 
 extension Context {
     /// Encodes `values` in the given format.
-    /// - Parameters:
-    ///   - values: Values to encode.
-    ///   - format: Encoding format.
-    ///   - moduliCount: Optional number of moduli. If not set, encoding will use the top-level ciphertext with all the
-    /// moduli.
-    /// - Returns: The plaintext encoding `values`.
-    /// - Throws: Error upon failure to encode.
-    @inlinable
-    public func encode<T: ScalarType>(
-        values: [some ScalarType],
-        format: EncodeFormat,
-        moduliCount: Int? = nil) throws -> Plaintext<Scheme, Eval>
-        where Scheme == Bfv<T>
-    {
-        let coeffPlaintext: Plaintext<Scheme, Coeff> = try encode(values: values, format: format)
-        return try coeffPlaintext.convertToEvalFormat(moduliCount: moduliCount)
-    }
-
-    /// Encodes `values` in the given format.
-    ///
-    /// Encoding will use the top-level ciphertext context with all moduli.
-    /// - Parameters:
-    ///   - values: Values to encode.
-    ///   - format: Encoding format.
-    /// - Returns: The plaintext encoding `values`.
-    /// - Throws: Error upon failure to encode.
-    @inlinable
-    public func encode<T: ScalarType>(values: [some ScalarType], format: EncodeFormat) throws -> Plaintext<Scheme, Eval>
-        where Scheme == Bfv<T>
-    {
-        let coeffPlaintext: Plaintext<Scheme, Coeff> = try encode(values: values, format: format)
-        return try coeffPlaintext.convertToEvalFormat(moduliCount: nil)
-    }
-}
-
-extension Context {
-    /// Encodes `values` in the given format.
-    /// - Parameters:
-    ///   - values: Values to encode.
-    ///   - format: Encoding format.
-    ///   - moduliCount: Optional number of moduli. If not set, encoding will use the top-level ciphertext with all the
-    /// moduli.
-    /// - Returns: The plaintext encoding `values`.
-    /// - Throws: Error upon failure to encode.
-    @inlinable
-    public func encode(values: [some ScalarType], format: EncodeFormat,
-                       moduliCount: Int? = nil) throws -> Plaintext<Scheme, Eval>
-    {
-        let coeffPlaintext: Plaintext<Scheme, Coeff> = try encode(values: values, format: format)
-        return try coeffPlaintext.convertToEvalFormat(moduliCount: moduliCount)
-    }
-
-    /// Encodes `values` in the given format.
-    ///
-    /// Encoding will use the top-level ciphertext context with all moduli.
-    /// - Parameters:
-    ///   - values: Values to encode.
-    ///   - format: Encoding format.
-    /// - Returns: The plaintext encoding `values`.
-    /// - Throws: Error upon failure to encode.
-    @inlinable
-    public func encode(values: [some ScalarType], format: EncodeFormat) throws -> Plaintext<Scheme, Eval> {
-        try encode(values: values, format: format, moduliCount: nil)
-    }
-
-    /// Encodes `values` in the given format.
     ///
     /// Encoding will use the top-level ciphertext context with all moduli.
     /// - Parameters:
@@ -99,6 +33,23 @@ extension Context {
         case .simd:
             return try encodeSimd(values: values)
         }
+    }
+
+    /// Encodes `values` in the given format.
+    /// - Parameters:
+    ///   - values: Values to encode.
+    ///   - format: Encoding format.
+    ///   - moduliCount: Optional number of moduli. If not set, encoding will use the top-level ciphertext with all the
+    /// moduli.
+    /// - Returns: The plaintext encoding `values`.
+    /// - Throws: Error upon failure to encode.
+    @inlinable
+    public func encode(
+        values: [some ScalarType],
+        format: EncodeFormat,
+        moduliCount: Int? = nil) throws -> Plaintext<Scheme, Eval>
+    {
+        try Scheme.encode(context: self, values: values, format: format, moduliCount: moduliCount)
     }
 
     /// Decodes a plaintext with the given format.
@@ -131,7 +82,7 @@ extension Context {
     public func decode<T: ScalarType>(plaintext: Plaintext<Scheme, Eval>,
                                       format: EncodeFormat) throws -> [T]
     {
-        try decode(plaintext: plaintext.convertToCoeffFormat(), format: format)
+        try Scheme.decode(plaintext: plaintext, format: format)
     }
 
     @inlinable

--- a/Sources/HomomorphicEncryption/HeScheme.swift
+++ b/Sources/HomomorphicEncryption/HeScheme.swift
@@ -63,6 +63,9 @@ public enum EncodeFormat: CaseIterable {
 }
 
 /// Protocol for HE schemes.
+///
+/// The protocol should be implemented when adding a new HE scheme.
+/// However, several functions have an alternative API which is more ergonomic and should be preferred.
 public protocol HeScheme {
     /// Coefficient type for each polynomial.
     associatedtype Scalar: ScalarType
@@ -140,6 +143,7 @@ public protocol HeScheme {
     ///   - format: Encoding format.
     /// - Returns: A plaintext encoding `values`.
     /// - Throws: Error upon failure to encode.
+    /// - seealso: ``Context/encode(values:format:)`` for an alternative API.
     static func encode(context: Context<Self>, values: [some ScalarType], format: EncodeFormat) throws -> CoeffPlaintext
 
     /// Encodes values into a plaintext with evaluation format.
@@ -149,22 +153,13 @@ public protocol HeScheme {
     ///   - context: Context for HE computation.
     ///   - values: Values to encode.
     ///   - format: Encoding format.
-    ///   - moduliCount: Number of coefficient moduli in the encoded plaintext.
+    ///   - moduliCount: Optional number of moduli. If not set, encoding will use the top-level ciphertext with all the
+    /// moduli.
     /// - Returns: A plaintext encoding `values`.
     /// - Throws: Error upon failure to encode.
+    /// - seealso: ``Context/encode(values:format:moduliCount:)`` for an alternative API.
     static func encode(context: Context<Self>, values: [some ScalarType], format: EncodeFormat,
-                       moduliCount: Int) throws -> EvalPlaintext
-
-    /// Encodes `values` into a plaintext with evaluation format and with top-level ciphertext context with all moduli.
-    /// - seealso: ``HeScheme/encode(context:values:format:moduliCount:)``
-    /// for an alternative which allows specifying the `moduliCount`.
-    /// - Parameters:
-    ///   - context: Context for HE computation.
-    ///   - values: Values to encode.
-    ///   - format: Encoding format.
-    /// - Returns: A plaintext encoding `values`.
-    /// - Throws: Error upon failure to encode.
-    static func encode(context: Context<Self>, values: [some ScalarType], format: EncodeFormat) throws -> EvalPlaintext
+                       moduliCount: Int?) throws -> EvalPlaintext
 
     /// Decodes a plaintext in ``Coeff`` format.
     /// - Parameters:

--- a/Sources/HomomorphicEncryption/NoOpScheme.swift
+++ b/Sources/HomomorphicEncryption/NoOpScheme.swift
@@ -53,15 +53,10 @@ public enum NoOpScheme: HeScheme {
     }
 
     public static func encode(context: Context<NoOpScheme>, values: [some ScalarType],
-                              format: EncodeFormat, moduliCount _: Int) throws -> EvalPlaintext
+                              format: EncodeFormat, moduliCount _: Int?) throws -> EvalPlaintext
     {
-        try encode(context: context, values: values, format: format).forwardNtt()
-    }
-
-    public static func encode(context: Context<NoOpScheme>, values: [some ScalarType],
-                              format: EncodeFormat) throws -> EvalPlaintext
-    {
-        try encode(context: context, values: values, format: format, moduliCount: 1)
+        let coeffPlaintext = try Self.encode(context: context, values: values, format: format)
+        return try EvalPlaintext(context: context, poly: coeffPlaintext.poly.forwardNtt())
     }
 
     public static func decode<T>(plaintext: CoeffPlaintext, format: EncodeFormat) throws -> [T] where T: ScalarType {

--- a/Sources/HomomorphicEncryption/Plaintext.swift
+++ b/Sources/HomomorphicEncryption/Plaintext.swift
@@ -176,8 +176,8 @@ extension Plaintext {
     /// - Throws: Error upon failure to decode the plaintext.
     /// - seealso: ``HeScheme/decode(plaintext:format:)-h6vl`` for an alternative API.
     @inlinable
-    public func decode(format: EncodeFormat) throws -> [Scheme.Scalar] where Format == Coeff {
-        try context.decode(plaintext: self, format: format)
+    public func decode<T: ScalarType>(format: EncodeFormat) throws -> [T] where Format == Coeff {
+        try Scheme.decode(plaintext: self, format: format)
     }
 
     /// Decodes a plaintext in ``Eval`` format.
@@ -186,8 +186,8 @@ extension Plaintext {
     /// - Throws: Error upon failure to decode the plaintext.
     /// - seealso: ``HeScheme/decode(plaintext:format:)-663x4`` for an alternative API.
     @inlinable
-    public func decode(format: EncodeFormat) throws -> [Scheme.Scalar] where Format == Eval {
-        try context.decode(plaintext: self, format: format)
+    public func decode<T: ScalarType>(format: EncodeFormat) throws -> [T] where Format == Eval {
+        try Scheme.decode(plaintext: self, format: format)
     }
 
     /// Symmetric secret key encryption of the plaintext.

--- a/Sources/HomomorphicEncryption/SerializedCiphertext.swift
+++ b/Sources/HomomorphicEncryption/SerializedCiphertext.swift
@@ -37,7 +37,8 @@ extension Ciphertext {
     /// - Parameters:
     ///   - serialized: Serialized ciphertext.
     ///   - context: Context to associate with the ciphertext.
-    ///   - moduliCount: Number of moduli in the serialized ciphertext.
+    ///   - moduliCount: Number of moduli in the serialized ciphertext. If not set, deserialization will use the
+    /// top-level ciphertext with all the moduli.
     /// - Throws: Error upon failure to deserialize the ciphertext.
     @inlinable
     public init(

--- a/Sources/HomomorphicEncryption/SerializedPlaintext.swift
+++ b/Sources/HomomorphicEncryption/SerializedPlaintext.swift
@@ -48,8 +48,9 @@ extension Plaintext where Format == Eval {
     /// - Parameters:
     ///   - serialized: Serialized plaintext.
     ///   - context: Context to associate with the plaintext.
-    ///   - moduliCount: Optional number of moduli to associate with the plaintext. If `nil`, the deserialized plaintext
-    /// will have the ciphertext context with `moduliCount` moduli.
+    ///   - moduliCount: Optional number of moduli to associate with the plaintext. If not set, the plaintext will have
+    /// the top-level ciphertext context with all the
+    /// moduli.
     /// - Throws: Error upon failure to deserialize.
     public init(deserialize serialized: SerializedPlaintext, context: Context<Scheme>, moduliCount: Int? = nil) throws {
         self.context = context

--- a/Sources/PrivateInformationRetrieval/MulPir.swift
+++ b/Sources/PrivateInformationRetrieval/MulPir.swift
@@ -453,7 +453,7 @@ extension MulPirServer {
                 if coefficients.allSatisfy({ $0 == 0 }) {
                     return nil
                 }
-                return try Scheme.encode(context: context, values: coefficients, format: .coefficient)
+                return try context.encode(values: coefficients, format: .coefficient)
             }
         }
 
@@ -502,7 +502,7 @@ extension MulPirServer {
                 if plaintextCoefficients.allSatisfy({ $0 == 0 }) {
                     return nil
                 }
-                return try Scheme.encode(context: context, values: plaintextCoefficients, format: .coefficient)
+                return try context.encode(values: plaintextCoefficients, format: .coefficient)
             }
         let perChunkPlaintextCount = IndexPir.computePerChunkPlaintextCount(for: parameter)
         while plaintexts.count < perChunkPlaintextCount {

--- a/Sources/PrivateInformationRetrieval/PirUtil.swift
+++ b/Sources/PrivateInformationRetrieval/PirUtil.swift
@@ -155,7 +155,7 @@ enum PirUtil<Scheme: HeScheme> {
         for index in nonZeroInputs {
             rawData[index] = inverseInputCountCeilLog
         }
-        return try Scheme.encode(context: context, values: rawData, format: .coefficient)
+        return try context.encode(values: rawData, format: .coefficient)
     }
 
     /// Generate the ciphertext based on the given non-zero positions.

--- a/Sources/TestUtilities/TestUtilities.swift
+++ b/Sources/TestUtilities/TestUtilities.swift
@@ -199,9 +199,7 @@ extension TestUtils {
     package static func getRandomPlaintextData<T: ScalarType>(count: Int,
                                                               in range: Range<T>) -> [T]
     {
-        (0..<count).map { _ in
-            T.random(in: range)
-        }
+        (0..<count).map { _ in T.random(in: range) }
     }
 
     package static func uniformnessTest<T>(poly: PolyRq<T, some Any>) {

--- a/Tests/HomomorphicEncryptionProtobufTests/ConversionTests.swift
+++ b/Tests/HomomorphicEncryptionProtobufTests/ConversionTests.swift
@@ -57,9 +57,9 @@ class ConversionTests: XCTestCase {
         func runTest<Scheme: HeScheme>(_: Scheme.Type) throws {
             let context: Context<Scheme> = try TestUtils.getTestContext()
             let values = TestUtils.getRandomPlaintextData(count: context.degree, in: 0..<context.plaintextModulus)
-            let plaintext: Scheme.CoeffPlaintext = try Scheme.encode(context: context,
-                                                                     values: values,
-                                                                     format: .coefficient)
+            let plaintext: Scheme.CoeffPlaintext = try context.encode(
+                values: values,
+                format: .coefficient)
             let secretKey = try context.generateSecretKey()
             let ciphertext = try plaintext.encrypt(using: secretKey)
 
@@ -128,7 +128,7 @@ class ConversionTests: XCTestCase {
                     context: context,
                     moduliCount: 1)
                 let decrypted = try deserialized.decrypt(using: secretKey)
-                let decoded = try decrypted.decode(format: .coefficient)
+                let decoded: [Scheme.Scalar] = try decrypted.decode(format: .coefficient)
                 for index in indices {
                     XCTAssertEqual(decoded[index], values[index])
                 }
@@ -153,17 +153,15 @@ class ConversionTests: XCTestCase {
             let context: Context<Scheme> = try TestUtils.getTestContext()
             let values = TestUtils.getRandomPlaintextData(count: context.degree, in: 0..<context.plaintextModulus)
             do { // CoeffPlaintext
-                let plaintext: Scheme.CoeffPlaintext = try Scheme.encode(context: context,
-                                                                         values: values,
-                                                                         format: format)
+                let plaintext: Scheme.CoeffPlaintext = try context.encode(values: values,
+                                                                          format: format)
                 let proto = plaintext.serialize().proto()
                 let deserialized: Scheme.CoeffPlaintext = try Plaintext(deserialize: proto.native(), context: context)
                 XCTAssertEqual(deserialized, plaintext)
             }
             do { // EvalPlaintext
-                let plaintext: Scheme.EvalPlaintext = try Scheme.encode(context: context,
-                                                                        values: values,
-                                                                        format: format)
+                let plaintext: Scheme.EvalPlaintext = try context.encode(values: values,
+                                                                         format: format)
                 let proto = plaintext.serialize().proto()
                 let deserialized: Scheme.EvalPlaintext = try Plaintext(deserialize: proto.native(), context: context)
                 XCTAssertEqual(deserialized, plaintext)
@@ -183,10 +181,10 @@ class ConversionTests: XCTestCase {
             let context: Context<Scheme> = try TestUtils.getTestContext()
             let values = TestUtils.getRandomPlaintextData(count: context.degree, in: 0..<context.plaintextModulus)
             for moduliCount in 1...context.ciphertextContext.moduli.count {
-                let plaintext: Scheme.EvalPlaintext = try Scheme.encode(context: context,
-                                                                        values: values,
-                                                                        format: format,
-                                                                        moduliCount: moduliCount)
+                let plaintext: Scheme.EvalPlaintext = try context.encode(
+                    values: values,
+                    format: format,
+                    moduliCount: moduliCount)
                 let proto = plaintext.serialize().proto()
                 let deserialized: Scheme.EvalPlaintext = try Plaintext(
                     deserialize: proto.native(),

--- a/Tests/HomomorphicEncryptionTests/HeAPITests.swift
+++ b/Tests/HomomorphicEncryptionTests/HeAPITests.swift
@@ -40,16 +40,12 @@ class HeAPITests: XCTestCase {
             self.context = context
             let polyDegree = context.degree
             let plaintextModulus = context.plaintextModulus
-            self.data1 = TestUtils.getRandomPlaintextData(
-                count: polyDegree,
-                in: 0..<Scheme.Scalar(plaintextModulus))
-            self.data2 = TestUtils.getRandomPlaintextData(
-                count: polyDegree,
-                in: 0..<Scheme.Scalar(plaintextModulus))
-            self.coeffPlaintext1 = try Scheme.encode(context: context, values: data1, format: format)
-            self.coeffPlaintext2 = try Scheme.encode(context: context, values: data2, format: format)
-            self.evalPlaintext1 = try Scheme.encode(context: context, values: data1, format: format)
-            self.evalPlaintext2 = try Scheme.encode(context: context, values: data2, format: format)
+            self.data1 = TestUtils.getRandomPlaintextData(count: polyDegree, in: 0..<plaintextModulus)
+            self.data2 = TestUtils.getRandomPlaintextData(count: polyDegree, in: 0..<plaintextModulus)
+            self.coeffPlaintext1 = try context.encode(values: data1, format: format)
+            self.coeffPlaintext2 = try context.encode(values: data2, format: format)
+            self.evalPlaintext1 = try context.encode(values: data1, format: format)
+            self.evalPlaintext2 = try context.encode(values: data2, format: format)
             self.secretKey = try Scheme.generateSecretKey(context: context)
             self.ciphertext1 = try Scheme.encrypt(coeffPlaintext1, using: secretKey)
             self.ciphertext2 = try Scheme.encrypt(coeffPlaintext2, using: secretKey)
@@ -202,10 +198,8 @@ class HeAPITests: XCTestCase {
         XCTAssert(evalCiphertext.isTransparent())
         XCTAssert(canonicalCiphertext.isTransparent())
 
-        let zeroPlaintext: Scheme.CoeffPlaintext = try Scheme.encode(
-            context: context,
-            values: zeros,
-            format: .coefficient)
+        let zeroPlaintext: Scheme.CoeffPlaintext = try context.encode(values: zeros,
+                                                                      format: .coefficient)
         let nonTransparentZero = try Scheme.encrypt(zeroPlaintext, using: testEnv.secretKey)
         if Scheme.self != NoOpScheme.self {
             XCTAssertFalse(nonTransparentZero.isTransparent())
@@ -246,7 +240,7 @@ class HeAPITests: XCTestCase {
 
         let zeroCiphertext: Ciphertext<Scheme, Eval> = try Scheme.zeroCiphertext(
             context: context,
-            moduliCount: context.ciphertextContext.moduli.count)
+            moduliCount: testEnv.evalPlaintext1.moduli.count)
         let product = try zeroCiphertext * testEnv.evalPlaintext1
         XCTAssert(product.isTransparent())
 
@@ -846,10 +840,10 @@ class HeAPITests: XCTestCase {
             var ciphertext = testEnv.ciphertext1
             try ciphertext.modSwitchDown()
             let evalCiphertext = try ciphertext.convertToEvalFormat()
-            let evalPlaintext = try Scheme.encode(context: testEnv.context,
-                                                  values: testEnv.data2,
-                                                  format: .simd,
-                                                  moduliCount: evalCiphertext.moduli.count)
+            let evalPlaintext = try testEnv.context.encode(
+                values: testEnv.data2,
+                format: .simd,
+                moduliCount: evalCiphertext.moduli.count)
             try testEnv.checkDecryptsDecodes(
                 ciphertext: evalCiphertext * evalPlaintext,
                 format: .simd,

--- a/Tests/HomomorphicEncryptionTests/SerializationTests.swift
+++ b/Tests/HomomorphicEncryptionTests/SerializationTests.swift
@@ -21,9 +21,9 @@ class SerializationTests: XCTestCase {
         func runTest<Scheme: HeScheme>(_: Scheme.Type) throws {
             let context: Context<Scheme> = try TestUtils.getTestContext()
             let values = TestUtils.getRandomPlaintextData(count: context.degree, in: 0..<context.plaintextModulus)
-            let plaintext: Scheme.CoeffPlaintext = try Scheme.encode(context: context,
-                                                                     values: values,
-                                                                     format: .coefficient)
+            let plaintext: Scheme.CoeffPlaintext = try context.encode(
+                values: values,
+                format: .coefficient)
             let secretKey = try context.generateSecretKey()
             let ciphertext = try plaintext.encrypt(using: secretKey)
 
@@ -91,7 +91,7 @@ class SerializationTests: XCTestCase {
                     context: context,
                     moduliCount: ciphertext.moduli.count)
                 let decrypted = try deserialized.decrypt(using: secretKey)
-                let decoded = try decrypted.decode(format: .coefficient)
+                let decoded: [Scheme.Scalar] = try decrypted.decode(format: .coefficient)
                 for index in indices {
                     XCTAssertEqual(decoded[index], values[index])
                 }
@@ -111,17 +111,15 @@ class SerializationTests: XCTestCase {
             let context: Context<Scheme> = try TestUtils.getTestContext()
             let values = TestUtils.getRandomPlaintextData(count: context.degree, in: 0..<context.plaintextModulus)
             do { // CoeffPlaintext
-                let plaintext: Scheme.CoeffPlaintext = try Scheme.encode(context: context,
-                                                                         values: values,
-                                                                         format: format)
+                let plaintext: Scheme.CoeffPlaintext = try context.encode(values: values,
+                                                                          format: format)
                 let serialized = plaintext.serialize()
                 let deserialized: Scheme.CoeffPlaintext = try Plaintext(deserialize: serialized, context: context)
                 XCTAssertEqual(deserialized, plaintext)
             }
             do { // EvalPlaintext
-                let plaintext: Scheme.EvalPlaintext = try Scheme.encode(context: context,
-                                                                        values: values,
-                                                                        format: format)
+                let plaintext: Scheme.EvalPlaintext = try context.encode(values: values,
+                                                                         format: format)
                 let serialized = plaintext.serialize()
                 let deserialized: Scheme.EvalPlaintext = try Plaintext(deserialize: serialized, context: context)
                 XCTAssertEqual(deserialized, plaintext)
@@ -141,10 +139,9 @@ class SerializationTests: XCTestCase {
             let context: Context<Scheme> = try TestUtils.getTestContext()
             let values = TestUtils.getRandomPlaintextData(count: context.degree, in: 0..<context.plaintextModulus)
             for moduliCount in 1...context.ciphertextContext.moduli.count {
-                let plaintext: Scheme.EvalPlaintext = try Scheme.encode(context: context,
-                                                                        values: values,
-                                                                        format: format,
-                                                                        moduliCount: moduliCount)
+                let plaintext: Scheme.EvalPlaintext = try context.encode(values: values,
+                                                                         format: format,
+                                                                         moduliCount: moduliCount)
                 let serialized = plaintext.serialize()
                 let deserialized: Scheme.EvalPlaintext = try Plaintext(
                     deserialize: serialized,

--- a/Tests/PrivateInformationRetrievalTests/PirUtilTests.swift
+++ b/Tests/PrivateInformationRetrievalTests/PirUtilTests.swift
@@ -45,9 +45,8 @@ class PirUtilTests: XCTestCase {
             let data: [Scheme.Scalar] = TestUtils.getRandomPlaintextData(
                 count: degree,
                 in: 0..<plaintextModulus)
-            let plaintext: Plaintext<Scheme, Coeff> = try Scheme.encode(context: context,
-                                                                        values: data,
-                                                                        format: .coefficient)
+            let plaintext: Plaintext<Scheme, Coeff> = try context.encode(values: data,
+                                                                         format: .coefficient)
             let secretKey = try context.generateSecretKey()
 
             let expandedQueryCount = degree


### PR DESCRIPTION
Cleans up some context encoding, making the NoOpScheme compatible with` context.{en,de}code` APIs.
The `Plaintext.decode` API is extended a bit to return `<T: ScalarType>`, rather than `Scheme.Scalar` (`Scheme.decode` already returned `Scheme.Scalar`).