### PR TITLE
Clean up zeroCiphertext & noiseBudget APIs

### DIFF
--- a/Sources/HomomorphicEncryption/Bfv/Bfv+Encrypt.swift
+++ b/Sources/HomomorphicEncryption/Bfv/Bfv+Encrypt.swift
@@ -21,7 +21,8 @@ extension Bfv {
 
     @inlinable
     // swiftlint:disable:next missing_docs attributes
-    public static func zeroCiphertext(context: Context<Self>, moduliCount: Int) throws -> CoeffCiphertext {
+    public static func zeroCiphertextCoeff(context: Context<Self>, moduliCount: Int?) throws -> CoeffCiphertext {
+        let moduliCount = moduliCount ?? context.ciphertextContext.moduli.count
         let zeroPoly = try PolyRq<Scalar, Coeff>.zero(
             context: context.ciphertextContext
                 .getContext(moduliCount: moduliCount))
@@ -31,7 +32,8 @@ extension Bfv {
 
     @inlinable
     // swiftlint:disable:next missing_docs attributes
-    public static func zeroCiphertext(context: Context<Self>, moduliCount: Int) throws -> EvalCiphertext {
+    public static func zeroCiphertextEval(context: Context<Self>, moduliCount: Int?) throws -> EvalCiphertext {
+        let moduliCount = moduliCount ?? context.ciphertextContext.moduli.count
         let zeroPoly = try PolyRq<Scalar, Eval>.zero(
             context: context.ciphertextContext
                 .getContext(moduliCount: moduliCount))

--- a/Sources/HomomorphicEncryption/Ciphertext.swift
+++ b/Sources/HomomorphicEncryption/Ciphertext.swift
@@ -41,6 +41,40 @@ public struct Ciphertext<Scheme: HeScheme, Format: PolyFormat>: Equatable, Senda
         self.seed = seed
     }
 
+    /// Generates a ciphertext of zeros.
+    ///
+    /// A zero ciphertext may arise from HE computations, e.g., by subtracting a ciphertext from itself, or multiplying
+    /// a ciphertext with a zero plaintext.
+    ///
+    /// - Parameters:
+    ///   - context: Context for HE computation.
+    ///   - moduliCount: Number of moduli in the zero ciphertext. If `nil`, the ciphertext will have the ciphertext
+    /// context with all the coefficient moduli in `context`.
+    /// - Returns: A zero ciphertext.
+    /// - Throws: Error upon failure to encode.
+    /// - Warning: a zero ciphertext is *transparent*, i.e., everyone can see the the underlying plaintext, zero in
+    /// this case. Transparency can propagate to ciphertexts operating with transparent ciphertexts, e.g.
+    /// ```
+    ///  transparentCiphertext * ciphertext = transparentCiphertext
+    ///  transparentCiphertext * plaintext = transparentCiphertext
+    ///  transparentCiphertext + plaintext = transparentCiphertext
+    /// ```
+    /// - seelaso: ``Ciphertext/isTransparent()``
+    @inlinable
+    public static func zero(context: Context<Scheme>, moduliCount: Int? = nil) throws -> Ciphertext<Scheme, Format> {
+        if Format.self == Coeff.self {
+            let coeffCiphertext = try Scheme.zeroCiphertextCoeff(context: context, moduliCount: moduliCount)
+            // swiftlint:disable:next force_cast
+            return coeffCiphertext as! Ciphertext<Scheme, Format>
+        }
+        if Format.self == Eval.self {
+            let evalCiphertext = try Scheme.zeroCiphertextEval(context: context, moduliCount: moduliCount)
+            // swiftlint:disable:next force_cast
+            return evalCiphertext as! Ciphertext<Scheme, Format>
+        }
+        throw HeError.unsupportedHeOperation()
+    }
+
     // MARK: ciphertext += plaintext
 
     @inlinable

--- a/Sources/HomomorphicEncryption/HeScheme.swift
+++ b/Sources/HomomorphicEncryption/HeScheme.swift
@@ -195,19 +195,20 @@ public protocol HeScheme {
     ///
     /// - Parameters:
     ///   - context: Context for HE computation.
-    ///   - moduliCount: Number of moduli in the zero ciphertext.
+    ///   - moduliCount: Number of moduli in the zero ciphertext. If `nil`, the ciphertext will have the ciphertext
+    /// context with all the coefficient moduli in `context`.
     /// - Returns: A zero ciphertext.
-    /// - Throws: Error upon failure to generate a zero ciphertext..
-    /// - Warning: a zero ciphertext is *transparent*, i.e., everyone can see the the underlying plaintext, zero in this
-    /// case.
-    /// Transparency can propagate to ciphertexts operating with transparent ciphertexts, e.g.
+    /// - Throws: Error upon failure to generate a zero ciphertext.
+    /// - Warning: a zero ciphertext is *transparent*, i.e., everyone can see the the underlying plaintext, zero in
+    /// this case. Transparency can propagate to ciphertexts operating with transparent ciphertexts, e.g.
     /// ```
     ///  transparentCiphertext * ciphertext = transparentCiphertext
     ///  transparentCiphertext * plaintext = transparentCiphertext
     ///  transparentCiphertext + plaintext = transparentCiphertext
     /// ```
     /// - seealso: ``HeScheme/isTransparent(ciphertext:)``
-    static func zeroCiphertext(context: Context<Self>, moduliCount: Int) throws -> CoeffCiphertext
+    /// - seealso: ``Ciphertext/zero(context:moduliCount:)`` for an alternative API.
+    static func zeroCiphertextCoeff(context: Context<Self>, moduliCount: Int?) throws -> CoeffCiphertext
 
     /// Generates a ciphertext of zeros in ``Eval`` format.
     ///
@@ -216,20 +217,20 @@ public protocol HeScheme {
     ///
     /// - Parameters:
     ///   - context: Context for HE computation.
-    ///   - moduliCount: Number of moduli in the zero ciphertext.
+    ///   - moduliCount: Number of moduli in the zero ciphertext. If `nil`, the ciphertext will have the ciphertext
+    /// context with all the coefficient moduli in `context`.
     /// - Returns: A zero ciphertext.
-    /// - Throws: Error upon failure to encode.
-    ///  - Warning: a zero ciphertext is *transparent*, i.e., everyone can see the the underlying plaintext, zero in
-    /// this
-    /// case.
-    /// Transparency can propagate to ciphertexts operating with transparent ciphertexts, e.g.
+    /// - Throws: Error upon failure to generate a zero ciphertext.
+    /// - Warning: a zero ciphertext is *transparent*, i.e., everyone can see the the underlying plaintext, zero in
+    /// this case. Transparency can propagate to ciphertexts operating with transparent ciphertexts, e.g.
     /// ```
     ///  transparentCiphertext * ciphertext = transparentCiphertext
     ///  transparentCiphertext * plaintext = transparentCiphertext
     ///  transparentCiphertext + plaintext = transparentCiphertext
     /// ```
     /// - seealso: ``HeScheme/isTransparent(ciphertext:)``
-    static func zeroCiphertext(context: Context<Self>, moduliCount: Int) throws -> EvalCiphertext
+    /// - seealso: ``Ciphertext/zero(context:moduliCount:)`` for an alternative API.
+    static func zeroCiphertextEval(context: Context<Self>, moduliCount: Int?) throws -> EvalCiphertext
 
     /// Computes whether a ciphertext is transparent.
     ///
@@ -862,7 +863,7 @@ extension HeScheme {
         }
         return try (zip(ciphertexts, plaintexts).map { ciphertext, plaintext in
             guard let plaintext else {
-                return try Self.zeroCiphertext(
+                return try EvalCiphertext.zero(
                     context: firstCiphertext.context,
                     moduliCount: firstCiphertext.moduli.count)
             }

--- a/Sources/HomomorphicEncryption/NoOpScheme.swift
+++ b/Sources/HomomorphicEncryption/NoOpScheme.swift
@@ -67,7 +67,7 @@ public enum NoOpScheme: HeScheme {
         try decode(plaintext: plaintext.inverseNtt(), format: format)
     }
 
-    public static func zeroCiphertext(context: Context<Self>, moduliCount _: Int) throws -> CoeffCiphertext {
+    public static func zeroCiphertextCoeff(context: Context<Self>, moduliCount _: Int?) throws -> CoeffCiphertext {
         NoOpScheme
             .CoeffCiphertext(
                 context: context,
@@ -75,7 +75,7 @@ public enum NoOpScheme: HeScheme {
                 correctionFactor: 1)
     }
 
-    public static func zeroCiphertext(context: Context<Self>, moduliCount _: Int) throws -> EvalCiphertext {
+    public static func zeroCiphertextEval(context: Context<Self>, moduliCount _: Int?) throws -> EvalCiphertext {
         NoOpScheme
             .EvalCiphertext(
                 context: context,

--- a/Sources/HomomorphicEncryption/SerializedPlaintext.swift
+++ b/Sources/HomomorphicEncryption/SerializedPlaintext.swift
@@ -49,8 +49,7 @@ extension Plaintext where Format == Eval {
     ///   - serialized: Serialized plaintext.
     ///   - context: Context to associate with the plaintext.
     ///   - moduliCount: Optional number of moduli to associate with the plaintext. If not set, the plaintext will have
-    /// the top-level ciphertext context with all the
-    /// moduli.
+    /// the top-level ciphertext context with all themoduli.
     /// - Throws: Error upon failure to deserialize.
     public init(deserialize serialized: SerializedPlaintext, context: Context<Scheme>, moduliCount: Int? = nil) throws {
         self.context = context

--- a/Sources/PrivateInformationRetrieval/KeywordDatabase.swift
+++ b/Sources/PrivateInformationRetrieval/KeywordDatabase.swift
@@ -418,7 +418,7 @@ public enum ProcessKeywordDatabase {
         let clock = ContinuousClock()
         var minNoiseBudget = Double.infinity
         let computeTimes = try (0..<trials).map { trial in
-            let secretKey = try Scheme.generateSecretKey(context: context)
+            let secretKey = try context.generateSecretKey()
             let trialEvaluationKey = try client.generateEvaluationKey(using: secretKey)
             let trialQuery = try client.generateQuery(at: row.keyword, using: secretKey)
             let computeTime = try clock.measure {

--- a/Sources/TestUtilities/TestUtilities.swift
+++ b/Sources/TestUtilities/TestUtilities.swift
@@ -360,7 +360,7 @@ extension TestUtils {
         try EncryptionParameters<Scheme>(
             polyDegree: testPolyDegree,
             plaintextModulus: Scheme.Scalar(testPlaintextModulus),
-            coefficientModuli: testCoefficientModuli(Scheme.Scalar.self).map { Scheme.Scalar($0) },
+            coefficientModuli: testCoefficientModuli(Scheme.Scalar.self),
             errorStdDev: ErrorStdDev.stdDev32,
             securityLevel: SecurityLevel.unchecked)
     }


### PR DESCRIPTION
* Move `zeroCiphertext` to `Ciphertext/zero`
* Also use `Context/` APIs in more places, instead of `Scheme/` APIs.