### PR TITLE
Rename bucketPerTable to bucketsPerTable

### DIFF
--- a/Sources/PrivateInformationRetrieval/CuckooTable.swift
+++ b/Sources/PrivateInformationRetrieval/CuckooTable.swift
@@ -243,7 +243,7 @@ struct CuckooTable {
         buckets.map(\.count).sum()
     }
 
-    @usableFromInline var bucketPerTable: Int { buckets.count / tableCount }
+    @usableFromInline var bucketsPerTable: Int { buckets.count / tableCount }
     @usableFromInline var tableCount: Int { config.multipleTables ? config.hashFunctionCount : 1 }
 
     init(
@@ -343,7 +343,7 @@ struct CuckooTable {
         }
         let keywordHashIndices = HashKeyword.hashIndices(
             keyword: keywordValuePair.keyword,
-            bucketCount: bucketPerTable,
+            bucketCount: bucketsPerTable,
             hashFunctionCount: config.hashFunctionCount).enumerated()
 
         // return if the keyword already exists
@@ -386,7 +386,7 @@ struct CuckooTable {
 
     @inlinable
     func index(tableIndex: Int, index: Int) -> Int {
-        tableCount == 1 ? index : tableIndex * bucketPerTable + index
+        tableCount == 1 ? index : tableIndex * bucketsPerTable + index
     }
 
     @inlinable
@@ -417,7 +417,7 @@ struct CuckooTable {
     subscript(_ keyword: KeywordValuePair.Keyword) -> KeywordValuePair.Value? {
         let keywordHashIndices = HashKeyword.hashIndices(
             keyword: keyword,
-            bucketCount: bucketPerTable,
+            bucketCount: bucketsPerTable,
             hashFunctionCount: config.hashFunctionCount).enumerated()
         for (tableIndex, hashIndex) in keywordHashIndices {
             let bucket = buckets[index(tableIndex: tableIndex, index: hashIndex)]

--- a/Sources/PrivateInformationRetrieval/KeywordPirProtocol.swift
+++ b/Sources/PrivateInformationRetrieval/KeywordPirProtocol.swift
@@ -183,7 +183,7 @@ public final class KeywordPirServer<PirServer: IndexPirServer>: KeywordPirProtoc
         }
 
         let indexPirConfig = try IndexPirConfig(
-            entryCount: cuckooTable.bucketPerTable,
+            entryCount: cuckooTable.bucketsPerTable,
             entrySizeInBytes: maxEntrySize,
             dimensionCount: config.dimensionCount,
             batchSize: cuckooTableConfig.hashFunctionCount,
@@ -194,9 +194,9 @@ public final class KeywordPirServer<PirServer: IndexPirServer>: KeywordPirProtoc
         let processedDb = try PirServer.Database(plaintexts: stride(
             from: 0,
             to: entryTable.count,
-            by: cuckooTable.bucketPerTable).flatMap { startIndex in
+            by: cuckooTable.bucketsPerTable).flatMap { startIndex in
             try PirServer.process(
-                database: entryTable[startIndex..<startIndex + cuckooTable.bucketPerTable],
+                database: entryTable[startIndex..<startIndex + cuckooTable.bucketsPerTable],
                 with: context,
                 using: indexPirParameter).plaintexts
         })

--- a/Tests/PrivateInformationRetrievalTests/CuckooTableTests.swift
+++ b/Tests/PrivateInformationRetrievalTests/CuckooTableTests.swift
@@ -30,7 +30,7 @@ class CuckooTableTests: XCTestCase {
         for entry in testDatabase {
             let indices = HashKeyword.hashIndices(
                 keyword: entry.keyword,
-                bucketCount: cuckooTable.bucketPerTable,
+                bucketCount: cuckooTable.bucketsPerTable,
                 hashFunctionCount: config.hashFunctionCount).enumerated()
             var foundEntry = false
             for (tableIndex, hashIndex) in indices {


### PR DESCRIPTION
"1 bucket per table" or "2 buckets per table" would be the spoken usage. But I find "bucketsPerTable" more clear.