### PR TITLE
Add missing Articles in rendered documentation

### DIFF
--- a/Sources/HomomorphicEncryption/HomomorphicEncryption.docc/HomomorphicEncryption.md
+++ b/Sources/HomomorphicEncryption/HomomorphicEncryption.docc/HomomorphicEncryption.md
@@ -36,8 +36,7 @@ This scheme can be configured to support post-quantum 128-bit security.
 > Consult a cryptography expert when developing and deploying homomorphic encryption applications.
 
 ## Topics
-
-### Articles
 <!-- Snippets are defined in a different "virtual module", requiring manually linking articles here. -->
+### Articles
 - <doc:DataFormats>
 - <doc:UsingSwiftHomomorphicEncryption>

--- a/Sources/PrivateInformationRetrieval/PrivateInformationRetrieval.docc/PrivateInformationRetrieval.md
+++ b/Sources/PrivateInformationRetrieval/PrivateInformationRetrieval.docc/PrivateInformationRetrieval.md
@@ -13,3 +13,9 @@ Then the server server sends the entire database to the client.
 While this *trivial PIR* protocol satisfies the privacy and correctness requirements of PIR, it is only feasible for small databases.
 
 The PIR implementation in Swift Homomorphic Encryption uses homomorphic encryption to improve upon the trivial PIR protocol.
+
+## Topics
+<!-- Snippets are defined in a different "virtual module", requiring manually linking articles here. -->
+### Articles
+- <doc:EncodingPipeline>
+- <doc:ParameterTuning>


### PR DESCRIPTION
https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrieval is missing the articles. 
But https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.0-lpha.3/documentation/privateinformationretrieval has them.

An improvement upon https://github.com/apple/swift-homomorphic-encryption/pull/55.