### PR TITLE
Implement PlaintextMatrix.diagonal encoding

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7ee1d955f789a2932c73eb859ad423a54265140cebf530f47f84bc523d26c86f",
+  "originHash" : "287ba43d965ab226c778e6332f9fbb9244920f2452fbe9bccef6f422c30d7e49",
   "pins" : [
     {
       "identity" : "hdrhistogram-swift",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "e8a5db026963f5bfeac842d9d3f2cc8cde323b49",
         "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms",
+      "state" : {
+        "revision" : "f6919dfc309e7f1b56224378b11e28bab5bccc42",
+        "version" : "1.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -51,6 +51,7 @@ let package = Package(
         .executable(name: "PIRShardDatabase", targets: ["PIRShardDatabase"]),
     ],
     dependencies: [
+        .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.4.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
@@ -96,7 +97,10 @@ let package = Package(
             swiftSettings: librarySettings),
         .target(
             name: "PrivateNearestNeighborsSearch",
-            dependencies: ["HomomorphicEncryption"],
+            dependencies: [
+                .product(name: "Algorithms", package: "swift-algorithms"),
+                "HomomorphicEncryption",
+            ],
             swiftSettings: librarySettings),
         .target(
             name: "TestUtilities",

--- a/Sources/HomomorphicEncryption/Array2d.swift
+++ b/Sources/HomomorphicEncryption/Array2d.swift
@@ -15,11 +15,11 @@
 /// Stores values in a 2 dimensional array.
 public struct Array2d<T: Equatable & AdditiveArithmetic & Sendable>: Equatable, Sendable {
     @usableFromInline package var data: [T]
-    @usableFromInline var rowCount: Int
-    @usableFromInline var columnCount: Int
+    @usableFromInline package var rowCount: Int
+    @usableFromInline package var columnCount: Int
 
-    @usableFromInline var shape: (Int, Int) { (rowCount, columnCount) }
-    @usableFromInline var count: Int { rowCount * columnCount }
+    @usableFromInline package var shape: (Int, Int) { (rowCount, columnCount) }
+    @usableFromInline package var count: Int { rowCount * columnCount }
 
     @inlinable
     package init(data: [T], rowCount: Int, columnCount: Int) {
@@ -35,26 +35,34 @@ public struct Array2d<T: Equatable & AdditiveArithmetic & Sendable>: Equatable, 
         self.rowCount = array.rowCount
         self.data = array.data.map { T($0) }
     }
+
+    @inlinable
+    package static func zero(rowCount: Int, columnCount: Int) -> Self {
+        self.init(
+            data: [T](Array(repeating: T.zero, count: rowCount * columnCount)),
+            rowCount: rowCount,
+            columnCount: columnCount)
+    }
 }
 
 extension Array2d {
     @inlinable
-    func index(row: Int, column: Int) -> Int {
+    package func index(row: Int, column: Int) -> Int {
         row &* columnCount &+ column
     }
 
     @inlinable
-    func rowIndices(row: Int) -> Range<Int> {
+    package func rowIndices(row: Int) -> Range<Int> {
         index(row: row, column: 0)..<index(row: row, column: columnCount)
     }
 
     @inlinable
-    func columnIndices(column: Int) -> StrideTo<Int> {
+    package func columnIndices(column: Int) -> StrideTo<Int> {
         stride(from: index(row: 0, column: column), to: index(row: rowCount, column: column), by: columnCount)
     }
 
     @inlinable
-    func row(row: Int) -> [T] {
+    package func row(row: Int) -> [T] {
         Array(data[rowIndices(row: row)])
     }
 
@@ -80,7 +88,7 @@ extension Array2d {
     }
 
     @inlinable
-    subscript(_ index: Int) -> T {
+    package subscript(_ index: Int) -> T {
         get {
             data[index]
         }
@@ -90,7 +98,7 @@ extension Array2d {
     }
 
     @inlinable
-    subscript(_ row: Int, _ column: Int) -> T {
+    package subscript(_ row: Int, _ column: Int) -> T {
         get {
             data[index(row: row, column: column)]
         }

--- a/Sources/HomomorphicEncryption/Encoding.swift
+++ b/Sources/HomomorphicEncryption/Encoding.swift
@@ -169,16 +169,11 @@ extension Context {
     func encodeSimd(values: [some ScalarType]) throws -> Plaintext<Scheme, Coeff> {
         guard !simdEncodingMatrix.isEmpty else { throw HeError.simdEncodingNotSupported(for: encryptionParameters) }
         let polyDegree = encryptionParameters.polyDegree
-        var array = Array2d<Scheme.Scalar>(
-            data: [Scheme.Scalar](repeating: 0,
-                                  count: polyDegree),
-            rowCount: 1,
-            columnCount: polyDegree)
+        var array = Array2d<Scheme.Scalar>.zero(rowCount: 1, columnCount: polyDegree)
         for index in 0..<values.count {
             array[0, simdEncodingMatrix[index]] = Scheme.Scalar(values[index])
         }
-        let poly = PolyRq<_, Eval>(context: plaintextContext,
-                                   data: array)
+        let poly = PolyRq<_, Eval>(context: plaintextContext, data: array)
         let coeffPoly = try poly.inverseNtt()
         return Plaintext<Scheme, Coeff>(context: self, poly: coeffPoly)
     }
@@ -189,10 +184,8 @@ extension Context {
             throw HeError.simdEncodingNotSupported(for: encryptionParameters)
         }
         let poly = try plaintext.poly.forwardNtt()
-        var values = [T](repeating: 0, count: encryptionParameters.polyDegree)
-        for index in 0..<encryptionParameters.polyDegree {
-            values[index] = T(poly.data[0, simdEncodingMatrix[index]])
+        return (0..<encryptionParameters.polyDegree).map { index in
+            T(poly.data[0, simdEncodingMatrix[index]])
         }
-        return values
     }
 }

--- a/Sources/HomomorphicEncryption/Scalar.swift
+++ b/Sources/HomomorphicEncryption/Scalar.swift
@@ -371,22 +371,40 @@ extension FixedWidthInteger {
         return self / divisor
     }
 
-    /// Computes the next value larger than or equal to this value that is a multiple of `factor`.
+    /// Computes the smallest value greater than or equal to this value that is a multiple of `rhs`.
     ///
     /// This value must be non-negative.
     /// - Parameters:
-    ///   - factor: Value of which the output is a product of.
+    ///   - rhs: Value of which the output is a multiple of.
     ///   - variableTime: Must be `true`, indicating this value and `other` are leaked through timing.
     /// - Returns: the next multiple of this value.
     /// - Warning: Leaks this value and `other` through timing.
     @inlinable
-    public func nextMultiple(of factor: Self, variableTime: Bool) -> Self {
+    public func nextMultiple(of rhs: Self, variableTime: Bool) -> Self {
         precondition(variableTime)
         precondition(self >= 0)
-        if factor == 0 {
+        if rhs == 0 {
             return 0
         }
-        return dividingCeil(factor, variableTime: true) * factor
+        return dividingCeil(rhs, variableTime: true) * rhs
+    }
+
+    /// Computes the largest value less than or equal to this value that is a multiple of `rhs`.
+    ///
+    /// This value must be non-negative.
+    /// - Parameters:
+    ///   - rhs: Value of which the output is a multiple of.
+    ///   - variableTime: Must be `true`, indicating this value and `other` are leaked through timing.
+    /// - Returns: the previous multiple of this value.
+    /// - Warning: Leaks this value and `other` through timing.
+    @inlinable
+    public func previousMultiple(of rhs: Self, variableTime: Bool) -> Self {
+        precondition(variableTime)
+        precondition(self >= 0)
+        if rhs == 0 {
+            return 0
+        }
+        return (self / rhs) * rhs
     }
 }
 

--- a/Sources/PrivateNearestNeighborsSearch/DotProduct.swift
+++ b/Sources/PrivateNearestNeighborsSearch/DotProduct.swift
@@ -1,0 +1,41 @@
+// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Pre-computed values for matrix-vector multiplication using baby-step, giant-step algorithm.
+///
+/// - seealso: Section 6.3 of <https://eprint.iacr.org/2018/244.pdf>.
+struct BabyStepGiantStep: Codable, Equatable, Hashable, Sendable {
+    /// Dimension of the vector; "D" in the reference.
+    let vectorDimension: Int
+    /// Baby step; "g" in the reference.
+    let babyStep: Int
+    /// Giant step; "h" in the reference.
+    let giantStep: Int
+
+    init(vectorDimension: Int, babyStep: Int, giantStep: Int) {
+        self.vectorDimension = vectorDimension
+        self.babyStep = babyStep
+        self.giantStep = giantStep
+    }
+
+    init(vectorDimension: Int) {
+        let dimension = Int32(vectorDimension).nextPowerOfTwo
+        let babyStep = Int32(Double(dimension).squareRoot().rounded(.up))
+        let giantStep = dimension.dividingCeil(babyStep, variableTime: true)
+
+        self.init(vectorDimension: Int(dimension), babyStep: Int(babyStep), giantStep: Int(giantStep))
+    }
+}

--- a/Tests/HomomorphicEncryptionTests/Array2dTests.swift
+++ b/Tests/HomomorphicEncryptionTests/Array2dTests.swift
@@ -16,7 +16,7 @@
 import XCTest
 
 class Array2dTests: XCTestCase {
-    func testZeroize() {
+    func testZeroAndZeroize() {
         func runTest<T: FixedWidthInteger & Sendable>(_: T.Type) {
             let data = [T](1...16)
             var array = Array2d(data: data, rowCount: 2, columnCount: 8)
@@ -27,6 +27,7 @@ class Array2dTests: XCTestCase {
                 rowCount: 2,
                 columnCount: 8)
             XCTAssertEqual(array, zero)
+            XCTAssertEqual(array, Array2d.zero(rowCount: 2, columnCount: 8))
         }
         runTest(Int.self)
         runTest(Int32.self)

--- a/Tests/HomomorphicEncryptionTests/ScalarTests.swift
+++ b/Tests/HomomorphicEncryptionTests/ScalarTests.swift
@@ -116,11 +116,19 @@ class ScalarTests: XCTestCase {
     }
 
     func testNextMultiple() {
-        XCTAssertEqual(0.nextMultiple(of: 7, variableTime: true), 0)
+        XCTAssertEqual(0.nextMultiple(of: 0, variableTime: true), 0)
         XCTAssertEqual(0.nextMultiple(of: 7, variableTime: true), 0)
         XCTAssertEqual(3.nextMultiple(of: 7, variableTime: true), 7)
         XCTAssertEqual(7.nextMultiple(of: 7, variableTime: true), 7)
         XCTAssertEqual(8.nextMultiple(of: 7, variableTime: true), 14)
+    }
+
+    func testPreviousMultiple() {
+        XCTAssertEqual(0.previousMultiple(of: 0, variableTime: true), 0)
+        XCTAssertEqual(0.previousMultiple(of: 7, variableTime: true), 0)
+        XCTAssertEqual(3.previousMultiple(of: 7, variableTime: true), 0)
+        XCTAssertEqual(7.previousMultiple(of: 7, variableTime: true), 7)
+        XCTAssertEqual(8.previousMultiple(of: 7, variableTime: true), 7)
     }
 
     func testIsPrime() {


### PR DESCRIPTION
Implement `plaintextMatrix.diagonal` packing.

For now, the `unpack` counterpart is unimplemented (it's never actually needed, but would be nice to have from an API completeness perspective).