### PR TITLE
Make decoding more generic

### DIFF
--- a/Sources/HomomorphicEncryption/Bfv/Bfv+Encode.swift
+++ b/Sources/HomomorphicEncryption/Bfv/Bfv+Encode.swift
@@ -63,27 +63,25 @@ extension Bfv {
 
     @inlinable
     // swiftlint:disable:next missing_docs attributes
-    public static func decode<V: ScalarType>(plaintext: CoeffPlaintext, format: EncodeFormat) throws -> [V] {
+    public static func decodeCoeff<V: ScalarType>(plaintext: CoeffPlaintext, format: EncodeFormat) throws -> [V] {
         try plaintext.context.decode(plaintext: plaintext, format: format)
     }
 
     @inlinable
     // swiftlint:disable:next missing_docs attributes
-    public static func decode<V: SignedScalarType>(plaintext: CoeffPlaintext, format: EncodeFormat) throws -> [V] {
+    public static func decodeCoeff<V: SignedScalarType>(plaintext: CoeffPlaintext, format: EncodeFormat) throws -> [V] {
         try plaintext.context.decode(plaintext: plaintext, format: format)
     }
 
     @inlinable
     // swiftlint:disable:next missing_docs attributes
-    public static func decode<V: ScalarType>(plaintext: EvalPlaintext, format: EncodeFormat) throws -> [V] {
-        let coeffPlaintext = try plaintext.convertToCoeffFormat()
-        return try coeffPlaintext.decode(format: format)
+    public static func decodeEval<V: ScalarType>(plaintext: EvalPlaintext, format: EncodeFormat) throws -> [V] {
+        try plaintext.convertToCoeffFormat().decode(format: format)
     }
 
     @inlinable
     // swiftlint:disable:next missing_docs attributes
-    public static func decode<V: SignedScalarType>(plaintext: EvalPlaintext, format: EncodeFormat) throws -> [V] {
-        let coeffPlaintext = try plaintext.convertToCoeffFormat()
-        return try coeffPlaintext.decode(format: format)
+    public static func decodeEval<V: SignedScalarType>(plaintext: EvalPlaintext, format: EncodeFormat) throws -> [V] {
+        try plaintext.convertToCoeffFormat().decode(format: format)
     }
 }

--- a/Sources/HomomorphicEncryption/Ciphertext.swift
+++ b/Sources/HomomorphicEncryption/Ciphertext.swift
@@ -63,17 +63,7 @@ public struct Ciphertext<Scheme: HeScheme, Format: PolyFormat>: Equatable, Senda
     /// - seelaso: ``Ciphertext/isTransparent()``
     @inlinable
     public static func zero(context: Context<Scheme>, moduliCount: Int? = nil) throws -> Ciphertext<Scheme, Format> {
-        if Format.self == Coeff.self {
-            let coeffCiphertext = try Scheme.zeroCiphertextCoeff(context: context, moduliCount: moduliCount)
-            // swiftlint:disable:next force_cast
-            return coeffCiphertext as! Ciphertext<Scheme, Format>
-        }
-        if Format.self == Eval.self {
-            let evalCiphertext = try Scheme.zeroCiphertextEval(context: context, moduliCount: moduliCount)
-            // swiftlint:disable:next force_cast
-            return evalCiphertext as! Ciphertext<Scheme, Format>
-        }
-        throw HeError.unsupportedHeOperation()
+        try Scheme.zero(context: context, moduliCount: moduliCount)
     }
 
     // MARK: ciphertext += plaintext

--- a/Sources/HomomorphicEncryption/Encoding.swift
+++ b/Sources/HomomorphicEncryption/Encoding.swift
@@ -96,8 +96,8 @@ extension Context {
     /// - Returns: The decoded values.
     /// - Throws: Error upon failure to decode.
     @inlinable
-    public func decode<T: ScalarType>(plaintext: Plaintext<Scheme, Coeff>,
-                                      format: EncodeFormat) throws -> [T]
+    func decode<T: ScalarType>(plaintext: Plaintext<Scheme, Coeff>,
+                               format: EncodeFormat) throws -> [T]
     {
         switch format {
         case .coefficient:
@@ -115,25 +115,11 @@ extension Context {
     /// - Returns: The decoded signed values.
     /// - Throws: Error upon failure to decode.
     @inlinable
-    public func decode<T: SignedScalarType>(plaintext: Plaintext<Scheme, Coeff>, format: EncodeFormat) throws -> [T] {
+    func decode<T: SignedScalarType>(plaintext: Plaintext<Scheme, Coeff>, format: EncodeFormat) throws -> [T] {
         let unsignedValues: [Scheme.Scalar] = try decode(plaintext: plaintext, format: format)
         return unsignedValues.map { value in
             T(value.remainderToCentered(modulus: plaintextModulus))
         }
-    }
-
-    /// Decodes a plaintext with the given format.
-    ///
-    /// - Parameters:
-    ///   - plaintext: Plaintext to decode.
-    ///   - format: Format to decode with.
-    /// - Returns: The decoded values.
-    /// - Throws: Error upon failure to decode.
-    @inlinable
-    public func decode<T: ScalarType>(plaintext: Plaintext<Scheme, Eval>,
-                                      format: EncodeFormat) throws -> [T]
-    {
-        try Scheme.decode(plaintext: plaintext, format: format)
     }
 
     /// Decodes a plaintext with the given format, into signed values.
@@ -144,8 +130,8 @@ extension Context {
     /// - Returns: The decoded signed values.
     /// - Throws: Error upon failure to decode.
     @inlinable
-    public func decode<T: SignedScalarType>(plaintext: Plaintext<Scheme, Eval>, format: EncodeFormat) throws -> [T] {
-        try Scheme.decode(plaintext: plaintext, format: format)
+    func decode<T: SignedScalarType>(plaintext: Plaintext<Scheme, Eval>, format: EncodeFormat) throws -> [T] {
+        try Scheme.decodeEval(plaintext: plaintext, format: format)
     }
 
     @inlinable

--- a/Sources/HomomorphicEncryption/NoOpScheme.swift
+++ b/Sources/HomomorphicEncryption/NoOpScheme.swift
@@ -85,24 +85,20 @@ public enum NoOpScheme: HeScheme {
         return try EvalPlaintext(context: context, poly: coeffPlaintext.poly.forwardNtt())
     }
 
-    public static func decode<T>(plaintext: CoeffPlaintext, format: EncodeFormat) throws -> [T] where T: ScalarType {
+    public static func decodeCoeff<T: ScalarType>(plaintext: CoeffPlaintext, format: EncodeFormat) throws -> [T] {
         try plaintext.context.decode(plaintext: plaintext, format: format)
     }
 
-    public static func decode<T>(plaintext: CoeffPlaintext, format: EncodeFormat) throws -> [T]
-        where T: SignedScalarType
-    {
+    public static func decodeEval<T: ScalarType>(plaintext: EvalPlaintext, format: EncodeFormat) throws -> [T] {
+        try plaintext.inverseNtt().decode(format: format)
+    }
+
+    public static func decodeCoeff<T: SignedScalarType>(plaintext: CoeffPlaintext, format: EncodeFormat) throws -> [T] {
         try plaintext.context.decode(plaintext: plaintext, format: format)
     }
 
-    public static func decode<T>(plaintext: EvalPlaintext, format: EncodeFormat) throws -> [T] where T: ScalarType {
-        try decode(plaintext: plaintext.inverseNtt(), format: format)
-    }
-
-    public static func decode<T>(plaintext: EvalPlaintext, format: EncodeFormat) throws -> [T]
-        where T: SignedScalarType
-    {
-        try decode(plaintext: plaintext.inverseNtt(), format: format)
+    public static func decodeEval<T: SignedScalarType>(plaintext: EvalPlaintext, format: EncodeFormat) throws -> [T] {
+        try plaintext.inverseNtt().decode(format: format)
     }
 
     public static func zeroCiphertextCoeff(context: Context<Self>, moduliCount _: Int?) throws -> CoeffCiphertext {

--- a/Sources/HomomorphicEncryption/Plaintext.swift
+++ b/Sources/HomomorphicEncryption/Plaintext.swift
@@ -174,41 +174,21 @@ extension Plaintext {
         return Plaintext<Scheme, Coeff>(context: context, poly: coeffPoly)
     }
 
-    /// Decodes a plaintext in ``Coeff`` format.
+    /// Decodes a plaintext.
     /// - Parameter format: Encoding format of the plaintext.
     /// - Returns: The decoded values.
     /// - Throws: Error upon failure to decode the plaintext.
-    /// - seealso: ``HeScheme/decode(plaintext:format:)-h6vl`` for an alternative API.
     @inlinable
-    public func decode<T: ScalarType>(format: EncodeFormat) throws -> [T] where Format == Coeff {
+    public func decode<T: ScalarType>(format: EncodeFormat) throws -> [T] {
         try Scheme.decode(plaintext: self, format: format)
     }
 
-    /// Decodes a plaintext in ``Coeff`` format to signed values.
+    /// Decodes a plaintext to signed values.
     /// - Parameter format: Encoding format of the plaintext.
     /// - Returns: The decoded signed values.
     /// - Throws: Error upon failure to decode the plaintext.
     @inlinable
-    public func decode<T: SignedScalarType>(format: EncodeFormat) throws -> [T] where Format == Coeff {
-        try Scheme.decode(plaintext: self, format: format)
-    }
-
-    /// Decodes a plaintext in ``Eval`` format.
-    /// - Parameter format: Encoding format of the plaintext.
-    /// - Returns: The decoded values.
-    /// - Throws: Error upon failure to decode the plaintext.
-    /// - seealso: ``HeScheme/decode(plaintext:format:)-663x4`` for an alternative API.
-    @inlinable
-    public func decode<T: ScalarType>(format: EncodeFormat) throws -> [T] where Format == Eval {
-        try Scheme.decode(plaintext: self, format: format)
-    }
-
-    /// Decodes a plaintext in ``Eval`` format to signed values.
-    /// - Parameter format: Encoding format of the plaintext.
-    /// - Returns: Error upon failure to decode the plaintext.
-    /// - Throws: Error upon failure to decode the plaintext.
-    @inlinable
-    public func decode<T: SignedScalarType>(format: EncodeFormat) throws -> [T] where Format == Eval {
+    public func decode<T: SignedScalarType>(format: EncodeFormat) throws -> [T] {
         try Scheme.decode(plaintext: self, format: format)
     }
 

--- a/Tests/HomomorphicEncryptionTests/HeAPITests.swift
+++ b/Tests/HomomorphicEncryptionTests/HeAPITests.swift
@@ -157,8 +157,7 @@ class HeAPITests: XCTestCase {
             let plaintextCoeffSigned: Plaintext<Scheme, Coeff> = try context.encode(
                 signedValues: signedData,
                 format: encodeFormat)
-            let roundTrip: [Scheme.Scalar.SignedScalar] = try context.decode(
-                plaintext: plaintextCoeffSigned,
+            let roundTrip: [Scheme.Scalar.SignedScalar] = try plaintextCoeffSigned.decode(
                 format: encodeFormat)
             XCTAssertEqual(roundTrip, signedData)
         case is Eval.Type:
@@ -1082,5 +1081,13 @@ class HeAPITests: XCTestCase {
 
     func testBfvUInt64() throws {
         try runBfvTests(UInt64.self)
+    }
+}
+
+/// This will compile if Plaintext.decode is generic across PolyFormat.
+extension Plaintext {
+    private func checkDecodeIsGeneric() throws {
+        let _: [Scheme.Scalar] = try decode(format: .coefficient)
+        let _: [Scheme.SignedScalar] = try decode(format: .coefficient)
     }
 }


### PR DESCRIPTION
I was trying to create an extension while debugging, but realized the below didn't work.
Instead it required `extension Plaintext where Format == Coeff`.

This PR:
* makes `Plaintext.decode` more generic to allow for generic extension.
* Removes `context.decode` from the public API, because I think it's confusing to have 2 APIs for the same thing. But we can also keep it, since it's symmetric with `context.encode`.
 
```swift
extension Plaintext {
    private func print(label: String = "") throws {
        let values: [Scheme.Scalar] = try decode(format: .simd)
        print("Plaintext \(label): \(values)")
    }
}
```