### PR TITLE
Add modular reduction and signed encoding to PlaintextMatrix.

### DIFF
--- a/Sources/HomomorphicEncryption/Array2d.swift
+++ b/Sources/HomomorphicEncryption/Array2d.swift
@@ -119,7 +119,7 @@ extension Array2d {
             throw HeError.invalidRotationParameter(range: range, columnCount: data.count)
         }
 
-        let effectiveStep = step.toRemainder(range)
+        let effectiveStep = step.toRemainder(range, variableTime: true)
         for index in stride(from: 0, to: data.count, by: range) {
             let replacement = data[index + effectiveStep..<index + range] + data[index..<index + effectiveStep]
             data.replaceSubrange(index..<index + range, with: replacement)

--- a/Sources/HomomorphicEncryption/Encoding.swift
+++ b/Sources/HomomorphicEncryption/Encoding.swift
@@ -51,7 +51,7 @@ extension Context {
             guard bounds.contains(Scheme.Scalar.SignedScalar(value)) else {
                 throw HeError.encodingDataOutOfBounds(for: bounds)
             }
-            return try Scheme.Scalar(value.centeredToRemainder(modulus: plaintextModulus))
+            return Scheme.Scalar(value.centeredToRemainder(modulus: plaintextModulus))
         }
         return try encode(values: centeredValues, format: format)
     }

--- a/Sources/HomomorphicEncryption/Util.swift
+++ b/Sources/HomomorphicEncryption/Util.swift
@@ -43,7 +43,8 @@ extension Sequence {
 extension FixedWidthInteger {
     // not a constant time operation
     @inlinable
-    func toRemainder(_ mod: Self) -> Self {
+    func toRemainder(_ mod: Self, variableTime: Bool) -> Self {
+        precondition(variableTime)
         precondition(mod > 0)
         var result = self % mod
         if result < 0 {

--- a/Tests/HomomorphicEncryptionTests/UtilTests.swift
+++ b/Tests/HomomorphicEncryptionTests/UtilTests.swift
@@ -38,12 +38,12 @@ class UtilTests: XCTestCase {
     }
 
     func testToRemainder() {
-        XCTAssertEqual((-8).toRemainder(7), 6)
-        XCTAssertEqual((-7).toRemainder(7), 0)
-        XCTAssertEqual((-6).toRemainder(7), 1)
-        XCTAssertEqual(6.toRemainder(7), 6)
-        XCTAssertEqual(7.toRemainder(7), 0)
-        XCTAssertEqual(8.toRemainder(7), 1)
+        XCTAssertEqual((-8).toRemainder(7, variableTime: true), 6)
+        XCTAssertEqual((-7).toRemainder(7, variableTime: true), 0)
+        XCTAssertEqual((-6).toRemainder(7, variableTime: true), 1)
+        XCTAssertEqual(6.toRemainder(7, variableTime: true), 6)
+        XCTAssertEqual(7.toRemainder(7, variableTime: true), 0)
+        XCTAssertEqual(8.toRemainder(7, variableTime: true), 1)
     }
 
     func testProduct() {


### PR DESCRIPTION
A few changes:
* Add modular reduction and signed encoding to PlaintextMatrix.
  * I thought about adding the modular reduction API to the HE layer as well, but it felt too ad-hoc, IMO. Maybe if we see this as a recurring pattern, we can add a `reduce: Bool = false` API to the `HEScheme` layer.
  * To helper adopters perform the modular reduction, we make the `Modulus` struct public.
  * We implement a new modular reduction for signed integers.
* Add `variableTime: Bool` to `toRemainder`
* Removing unnecessary `throws` from `centeredToRemainder`