### PR TITLE
Adds PrivateNearestNeighbhorsSearch Client

### DIFF
--- a/Sources/HomomorphicEncryption/Array2d.swift
+++ b/Sources/HomomorphicEncryption/Array2d.swift
@@ -14,12 +14,18 @@
 
 /// Stores values in a 2 dimensional array.
 public struct Array2d<T: Equatable & AdditiveArithmetic & Sendable>: Equatable, Sendable {
+    /// Values stored in row-major order.
     @usableFromInline package var data: [T]
     @usableFromInline package var rowCount: Int
     @usableFromInline package var columnCount: Int
 
     @usableFromInline package var shape: (Int, Int) { (rowCount, columnCount) }
     @usableFromInline package var count: Int { rowCount * columnCount }
+
+    @inlinable
+    package init(data: [[T]]) {
+        self.init(data: data.flatMap { $0 }, rowCount: data.count, columnCount: data[0].count)
+    }
 
     @inlinable
     package init(data: [T], rowCount: Int, columnCount: Int) {
@@ -174,5 +180,17 @@ extension Array2d {
             // swiftlint:disable:next force_unwrapping
             HomomorphicEncryption.zeroize(dataPointer.baseAddress!, zeroizeSize)
         }
+    }
+
+    /// Returns the matrix after transforming each entry with a function.
+    /// - Parameter transform: A mapping closure. `transform` accepts an element of the array as its parameter and
+    /// returns a transformed value of the same or of a different type.
+    /// - Returns: The transformed matrix.
+    @inlinable
+    package func map<V: Equatable & AdditiveArithmetic & Sendable>(_ transform: (T) -> (V)) -> Array2d<V> {
+        Array2d<V>(
+            data: data.map { value in transform(value) },
+            rowCount: rowCount,
+            columnCount: columnCount)
     }
 }

--- a/Sources/HomomorphicEncryption/Ciphertext.swift
+++ b/Sources/HomomorphicEncryption/Ciphertext.swift
@@ -292,7 +292,7 @@ public struct Ciphertext<Scheme: HeScheme, Format: PolyFormat>: Equatable, Senda
     /// ``HeScheme/minNoiseBudget``, decryption may yield inaccurate plaintexts.
     /// - Parameters:
     ///   - secretKey: Secret key.
-    ///   - variableTime: Must be `true`, indicating the secret key coefficients are leaked through timing.
+    ///   - variableTime: If `true`, indicates the secret key coefficients may be leaked through timing.
     /// - Returns: The noise budget.
     /// - Throws: Error upon failure to compute the noise budget.
     /// - Warning: Leaks `secretKey` through timing. Should be used for testing only.

--- a/Sources/HomomorphicEncryption/CrtComposer.swift
+++ b/Sources/HomomorphicEncryption/CrtComposer.swift
@@ -1,0 +1,116 @@
+// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Performs Chinese remainder theorem (CRT) composition of coefficients.
+@usableFromInline
+package struct CrtComposer<T: ScalarType>: Sendable {
+    /// Context for the CRT moduli `q_i`.
+    @usableFromInline let polyContext: PolyContext<T>
+
+    /// i'th entry stores `(q_i / q) % q_i`.
+    @usableFromInline let inversePuncturedProducts: [MultiplyConstantModulus<T>]
+
+    /// Creates a new ``CrtComposer``.
+    /// - Parameter polyContext: Context for the CRT moduli.
+    /// - Throws: Error upon failure to create a new ``CrtComposer``.
+    @inlinable
+    package init(polyContext: PolyContext<T>) throws {
+        self.polyContext = polyContext
+        self.inversePuncturedProducts = try polyContext.reduceModuli.map { qi in
+            var puncturedProduct = T(1)
+            for qj in polyContext.moduli where qj != qi.modulus {
+                let prod = puncturedProduct.multipliedFullWidth(by: qj)
+                puncturedProduct = qi.reduce(T.DoubleWidth(prod))
+            }
+            let inversePuncturedProduct = try puncturedProduct.inverseMod(
+                modulus: qi.modulus,
+                variableTime: true)
+            return MultiplyConstantModulus(
+                multiplicand: inversePuncturedProduct,
+                modulus: qi.modulus,
+                variableTime: true)
+        }
+    }
+
+    /// Returns an upper bound on the maximum value during a `crtCompose` call.
+    /// - Parameter moduli: Moduli in the polynomial context
+    /// - Returns: The upper bound.
+    @inlinable
+    package static func composeMaxIntermediateValue(moduli: [T]) -> Double {
+        let moduli = moduli.map { Double($0) }
+        if moduli.count == 1 {
+            return moduli[0]
+        }
+        let q = moduli.reduce(1.0, *)
+        return 2.0 * q
+    }
+
+    /// Performs Chinese remainder theorem (CRT) composition on a list of
+    /// coefficients.
+    ///
+    /// The composition yields a polynomial with coefficients in `[0, q - 1]`.
+    /// - Parameter data:Data to compose. Each column must contain a
+    /// coefficient's residues mod each modulus.
+    /// - Returns: The composed coefficients. Each coefficient must be able to
+    /// store values up to
+    /// `crtComposeMaxIntermediateValue`.
+    /// - Throws: `HeError` upon failure to compose the polynomial.
+    /// - Warning: `V`'s operations must be constant time to prevent leaking
+    /// `poly` through timing.
+    @inlinable
+    package func compose<V: FixedWidthInteger &
+        UnsignedInteger>(data: Array2d<T>) throws -> [V]
+    {
+        precondition(data.rowCount == polyContext.moduli.count)
+        precondition(Double(V.max) >= Self
+            .composeMaxIntermediateValue(moduli: polyContext.moduli))
+        let q: V = polyContext.moduli.product()
+        let puncturedProducts = polyContext.moduli.map { qi in q / V(qi) }
+
+        var products: [V] = Array(repeating: 0, count: data.columnCount)
+        for row in 0..<data.rowCount {
+            let puncturedProduct = puncturedProducts[row]
+            let inversePuncturedProduct = inversePuncturedProducts[row]
+            for column in 0..<data.columnCount {
+                let tmp = V(inversePuncturedProduct.multiplyMod(data[
+                    row,
+                    column
+                ]))
+                let addend = tmp &* puncturedProduct
+                products[column] = products[column].addMod(addend, modulus: q)
+            }
+        }
+        return products
+    }
+
+    /// Performs Chinese remainder theorem (CRT) composition on a polynomial's
+    /// coefficients.
+    ///
+    /// The composition yields a polynomial with coefficients in `[0, q)`.
+    /// - Parameter poly: Polynomial whose coefficients to compose. Must have the
+    /// same context as ``polyContext``.
+    /// - Returns: The composed coefficients. Each coefficient must be able to
+    /// store values up to
+    /// `crtComposeMaxIntermediateValue`.
+    /// - Throws: `HeError` upon failure to compose the polynomial.
+    /// - Warning: `V`'s operations must be constant time to prevent leaking
+    /// `poly` through timing.
+    @inlinable
+    package func compose<V: FixedWidthInteger & UnsignedInteger>(poly: PolyRq<
+        T,
+        Coeff
+    >) throws -> [V] {
+        try compose(data: poly.data)
+    }
+}

--- a/Sources/HomomorphicEncryption/HeScheme.swift
+++ b/Sources/HomomorphicEncryption/HeScheme.swift
@@ -636,7 +636,7 @@ public protocol HeScheme {
     /// - Parameters:
     ///   - ciphertext: Ciphertext whose noise budget to compute.
     ///   - secretKey: Secret key.
-    ///   - variableTime: Must be `true`, indicating the secret key coefficients are leaked through timing.
+    ///   - variableTime: If `true`, indicates the secret key coefficients may be leaked through timing.
     /// - Returns: The noise budget.
     /// - Throws: Error upon failure to compute the noise budget.
     /// - Warning: Leaks `secretKey` through timing. Should be used for testing only.
@@ -651,7 +651,7 @@ public protocol HeScheme {
     /// - Parameters:
     ///   - ciphertext: Ciphertext whose noise budget to compute.
     ///   - secretKey: Secret key.
-    ///   - variableTime: Must be `true`, indicating the secret key coefficients are leaked through timing.
+    ///   - variableTime: If `true`, indicates the secret key coefficients may be leaked through timing.
     /// - Returns: The noise budget.
     /// - Throws: Error upon failure to compute the noise budget.
     /// - Warning: Leaks `secretKey` through timing. Should be used for testing only.

--- a/Sources/HomomorphicEncryption/PolyRq/PolyContext.swift
+++ b/Sources/HomomorphicEncryption/PolyRq/PolyContext.swift
@@ -18,7 +18,7 @@ public final class PolyContext<T: ScalarType>: Sendable {
     /// Number `N` of coefficients in the polynomial, must be a power of two.
     @usableFromInline let degree: Int
     /// CRT-representation of the modulus `Q = product_{i=0}^{L-1} q_i`.
-    @usableFromInline let moduli: [T]
+    @usableFromInline package let moduli: [T]
     /// Next context, typically formed by dropping `q_{L-1}`.
     @usableFromInline let next: PolyContext<T>?
     /// Operations mod `q_0` up to `q_{L-1}`.

--- a/Sources/HomomorphicEncryption/RnsTool.swift
+++ b/Sources/HomomorphicEncryption/RnsTool.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 @usableFromInline
-struct RnsTool<T: ScalarType>: Sendable {
+package struct RnsTool<T: ScalarType>: Sendable {
     /// `Q = q_0, ..., q_{L-1}`.
     @usableFromInline let inputContext: PolyContext<T>
     /// `t_0, ..., t_{M-1}`.
@@ -396,17 +396,16 @@ struct RnsTool<T: ScalarType>: Sendable {
     ///   - poly: Polynomial whose coefficients to compose.
     ///   - variableTime: Must be `true`, indicating the coefficients of the polynomial are leaked through timing.
     /// - Returns: The coefficients of `poly`, each in `[0, Q - 1]`.
-    /// - Warning: Leaks `poly` through timing.
+    /// - Warning: `V`'s operations must be constant time to prevent leaking `poly` through timing.
     @inlinable
-    func crtCompose<V: FixedWidthInteger>(poly: PolyRq<T, Coeff>, variableTime: Bool) throws -> [V] {
-        precondition(variableTime)
+    package func crtCompose<V: FixedWidthInteger & UnsignedInteger>(poly: PolyRq<T, Coeff>) throws -> [V] {
         // Use arbitrary base converter that has same inputContext
-        return try rnsConvertQToBSk.crtCompose(poly: poly, variableTime: variableTime)
+        try rnsConvertQToBSk.crtCompose(poly: poly)
     }
 
     /// Returns an upper bound on the maximum value during a `crtCompose` call.
     @inlinable
-    func crtComposeMaxIntermediateValue() -> Double {
-        rnsConvertQToBSk.crtComposeMaxIntermediateValue()
+    package func crtComposeMaxIntermediateValue() -> Double {
+        CrtComposer.composeMaxIntermediateValue(moduli: inputContext.moduli)
     }
 }

--- a/Sources/HomomorphicEncryption/Scalar.swift
+++ b/Sources/HomomorphicEncryption/Scalar.swift
@@ -206,7 +206,7 @@ extension FixedWidthInteger {
     }
 }
 
-extension ScalarType {
+extension UnsignedInteger where Self: FixedWidthInteger {
     /// Computes the high `Self.bitWidth` bits of `self * rhs`.
     /// - Parameter rhs: Multiplicand.
     /// - Returns: the high `Self.bitWidth` bits  of `self * rhs`.
@@ -269,7 +269,9 @@ extension ScalarType {
         let sum = self &+ modulus &- rhs
         return sum.subtractIfExceeds(modulus)
     }
+}
 
+extension ScalarType {
     /// Computes modular exponentiation.
     ///
     /// Computes self raised to the power of `exponent` mod `modulus, i.e., `self^exponent mod modulus`.

--- a/Sources/PrivateNearestNeighborsSearch/Client.swift
+++ b/Sources/PrivateNearestNeighborsSearch/Client.swift
@@ -1,0 +1,187 @@
+// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Algorithms
+import Foundation
+import HomomorphicEncryption
+
+/// Private nearest neighbors client.
+struct Client<Scheme: HeScheme> {
+    /// Configuration.
+    let config: ClientConfig<Scheme>
+
+    /// One context per plaintext modulus.
+    let contexts: [Context<Scheme>]
+
+    /// Performs composition of the plaintext CRT responses.
+    let crtComposer: CrtComposer<Scheme.Scalar>
+
+    /// Context for the plaintext CRT moduli.
+    let plaintextContext: PolyContext<Scheme.Scalar>
+
+    var evaluationKeyConfiguration: HomomorphicEncryption.EvaluationKeyConfiguration {
+        config.evaluationKeyConfig
+    }
+
+    /// Creates a new ``Client``.
+    /// - Parameter config: Client configuration.
+    /// - Throws: Error upon failure to create a new client.
+    @inlinable
+    init(config: ClientConfig<Scheme>) throws {
+        guard config.distanceMetric == .cosineSimilarity else {
+            throw PnnsError.wrongDistanceMetric(got: config.distanceMetric, expected: .cosineSimilarity)
+        }
+        self.config = config
+        let extraEncryptionParams = try config.extraPlaintextModuli.map { plaintextModulus in
+            try EncryptionParameters<Scheme>(
+                polyDegree: config.encryptionParams.polyDegree,
+                plaintextModulus: plaintextModulus,
+                coefficientModuli: config.encryptionParams.coefficientModuli,
+                errorStdDev: config.encryptionParams.errorStdDev,
+                securityLevel: config.encryptionParams.securityLevel)
+        }
+        let encryptionParams = [config.encryptionParams] + extraEncryptionParams
+        self.contexts = try encryptionParams.map { encryptionParams in
+            try Context(encryptionParameters: encryptionParams)
+        }
+        self.plaintextContext = try PolyContext(
+            degree: config.encryptionParams.polyDegree,
+            moduli: config.plaintextModuli)
+        self.crtComposer = try CrtComposer(polyContext: plaintextContext)
+    }
+
+    /// Generates a nearest neighbor search query.
+    /// - Parameters:
+    ///   - vectors: Vectors.
+    ///   - secretKey: Secret key to encrypt with.
+    /// - Returns: The query.
+    /// - Throws: Error upon failure to generate the query.
+    @inlinable
+    func generateQuery(vectors: Array2d<Float>, using secretKey: SecretKey<Scheme>) throws -> Query<Scheme> {
+        let scaledVectors: Array2d<Scheme.SignedScalar> = vectors.normalizedRows(norm: Array2d<Float>.Norm.Lp(p: 2.0))
+            .scaled(by: Float(config.scalingFactor)).rounded()
+        let dimensions = try MatrixDimensions(rowCount: vectors.rowCount, columnCount: vectors.columnCount)
+
+        let matrices = try contexts.map { context in
+            // For a single plaintext modulus, reduction isn't necessary
+            let shouldReduce = contexts.count > 1
+            let plaintextMatrix = try PlaintextMatrix(
+                context: context,
+                dimensions: dimensions,
+                packing: config.queryPacking,
+                signedValues: scaledVectors.data,
+                reduce: shouldReduce)
+            return try plaintextMatrix.encrypt(using: secretKey).convertToCoeffFormat()
+        }
+        return Query(ciphertextMatrices: matrices)
+    }
+
+    /// Decrypts a nearest neighbors search response.
+    /// - Parameters:
+    ///   - response: The response.
+    ///   - secretKey: Secret key to decrypt with.
+    /// - Returns: The distances from the query vectors to the database rows.
+    /// - Throws: Error upon failure to decrypt the response.
+    @inlinable
+    func decrypt(response: Response<Scheme>, using secretKey: SecretKey<Scheme>) throws -> DatabaseDistances {
+        guard let dimensions = response.ciphertextMatrices.first?.dimensions else {
+            throw PnnsError.emptyCiphertextArray
+        }
+        let decoded: [[Scheme.Scalar]] = try response.ciphertextMatrices.map { ciphertextMatrix in
+            try ciphertextMatrix.decrypt(using: secretKey).unpack()
+        }
+        // CRT-decomposed scores
+        let values = Array2d<Scheme.Scalar>(data: decoded)
+        // Plaintext CRT modulus must be < `UInt64.max`
+        let composedDistances: [UInt64] = try crtComposer.compose(data: values)
+
+        let modulus: UInt64 = plaintextContext.moduli.product()
+        // Encrypted distances are scaled by config.scalingFactor^2, so we undo the scaling here.
+        let distanceValues = composedDistances.map { unsigned in
+            let signed = unsigned.remainderToCentered(modulus: modulus)
+            return Float(signed) / (Float(config.scalingFactor) * Float(config.scalingFactor))
+        }
+
+        let distances = Array2d(
+            data: distanceValues,
+            rowCount: dimensions.rowCount,
+            columnCount: dimensions.columnCount)
+        return DatabaseDistances(
+            distances: distances,
+            entryIDs: response.entryIDs,
+            entryMetadatas: response.entryMetadatas)
+    }
+
+    /// Generates an ``EvaluationKey`` for use in nearest neighbors search.
+    /// - Parameter secretKey: Secret key used to generate the evaluation key.
+    /// - Returns: The evaluation key.
+    /// - Throws: Error upon failure to generate the evaluation key.
+    /// - Warning: Uses the first context to generate the evaluation key. So either the HE scheme should generate
+    /// evaluation keys independent of the plaintext modulus (as in BFV), or there should be just one plaintext modulus.
+    @inlinable
+    func generateEvaluationKey(using secretKey: SecretKey<Scheme>) throws -> EvaluationKey<Scheme> {
+        try contexts[0].generateEvaluationKey(configuration: evaluationKeyConfiguration, using: secretKey)
+    }
+}
+
+extension Array2d where T == Float {
+    /// A mapping from vectors to non-negative real numbers.
+    @usableFromInline
+    enum Norm {
+        case Lp(p: Float) // sum_i (|x_i|^p)^{1/p}
+    }
+
+    /// Normalizes each row in the matrix.
+    @inlinable
+    func normalizedRows(norm: Norm) -> Array2d<Float> {
+        switch norm {
+        case let Norm.Lp(p):
+            let normalizedValues = data.chunks(ofCount: columnCount).flatMap { row in
+                let sumOfPowers = row.map { pow($0, p) }.reduce(0, +)
+                let norm = pow(sumOfPowers, 1 / p)
+                return row.map { value in
+                    if sumOfPowers.isZero {
+                        Float.zero
+                    } else {
+                        value / norm
+                    }
+                }
+            }
+            return Array2d<Float>(
+                data: normalizedValues,
+                rowCount: rowCount,
+                columnCount: columnCount)
+        }
+    }
+
+    /// Returns the matrix where each entry is rounded to the closest integer.
+    @inlinable
+    func rounded<V: FixedWidthInteger & SignedInteger>() -> Array2d<V> {
+        Array2d<V>(
+            data: data.map { value in V(value.rounded()) },
+            rowCount: rowCount,
+            columnCount: columnCount)
+    }
+
+    /// Returns the matrix where each entry has been multiplied by a scaling factor.
+    /// - Parameter scalingFactor: The factor to multiply each entry by.
+    /// - Returns: The scaled matrix.
+    @inlinable
+    func scaled(by scalingFactor: Float) -> Array2d<Float> {
+        Array2d<Float>(
+            data: data.map { value in value * scalingFactor },
+            rowCount: rowCount,
+            columnCount: columnCount)
+    }
+}

--- a/Sources/PrivateNearestNeighborsSearch/Config.swift
+++ b/Sources/PrivateNearestNeighborsSearch/Config.swift
@@ -39,6 +39,11 @@ public struct ClientConfig<Scheme: HeScheme>: Codable, Equatable, Hashable, Send
     /// The first plaintext modulus will be the one in ``ClientConfig/encryptionParams``.
     public let extraPlaintextModuli: [Scheme.Scalar]
 
+    /// The plaintext CRT moduli.
+    var plaintextModuli: [Scheme.Scalar] {
+        [encryptionParams.plaintextModulus] + extraPlaintextModuli
+    }
+
     /// Creates a new ``ClientConfig``.
     /// - Parameters:
     ///   - encryptionParams: Encryption parameters.
@@ -65,6 +70,15 @@ public struct ClientConfig<Scheme: HeScheme>: Codable, Equatable, Hashable, Send
         self.evaluationKeyConfig = evaluationKeyConfig
         self.distanceMetric = distanceMetric
         self.extraPlaintextModuli = extraPlaintextModuli
+    }
+
+    static func maxScalingFactor(vectorDimension: Int, distanceMetric: DistanceMetric,
+                                 plaintextModuli: [Scheme.Scalar]) -> Int
+    {
+        precondition(distanceMetric == .cosineSimilarity)
+        let t = plaintextModuli.map { Float($0) }.reduce(1, *)
+        let scalingFactor = (((t - 1) / 2).squareRoot() - Float(vectorDimension).squareRoot() / 2).rounded(.down)
+        return Int(scalingFactor)
     }
 }
 

--- a/Sources/PrivateNearestNeighborsSearch/Error.swift
+++ b/Sources/PrivateNearestNeighborsSearch/Error.swift
@@ -23,6 +23,7 @@ public enum PnnsError: Error, Equatable {
     case simdEncodingNotSupported(_ description: String)
     case wrongCiphertextCount(got: Int, expected: Int)
     case wrongContext(gotDescription: String, expectedDescription: String)
+    case wrongDistanceMetric(got: DistanceMetric, expected: DistanceMetric)
     case wrongEncodingValuesCount(got: Int, expected: Int)
     case wrongMatrixPacking(got: MatrixPacking, expected: MatrixPacking)
     case wrongPlaintextCount(got: Int, expected: Int)
@@ -55,6 +56,8 @@ extension PnnsError: LocalizedError {
             "Wrong ciphertext count \(got), expected \(expected)"
         case let .wrongContext(gotDescription, expectedDescription):
             "Wrong context: got \(gotDescription), expected \(expectedDescription)"
+        case let .wrongDistanceMetric(got, expected):
+            "Wrong distance metric: got \(got), expected \(expected)"
         case let .wrongEncodingValuesCount(got, expected):
             "Wrong encoding values count \(got), expected \(expected)"
         case let .wrongMatrixPacking(got: got, expected: expected):

--- a/Sources/PrivateNearestNeighborsSearch/PnnsProtocol.swift
+++ b/Sources/PrivateNearestNeighborsSearch/PnnsProtocol.swift
@@ -1,0 +1,41 @@
+// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import HomomorphicEncryption
+
+/// A nearest neighbor search query.
+struct Query<Scheme: HeScheme>: Sendable {
+    // Encrypted query; one matrix per plaintext CRT modulus
+    let ciphertextMatrices: [CiphertextMatrix<Scheme, Coeff>]
+}
+
+/// A nearest neighbor search response.
+struct Response<Scheme: HeScheme>: Sendable {
+    // Encrypted response; one matrix per plaintext CRT modulus
+    let ciphertextMatrices: [CiphertextMatrix<Scheme, Coeff>]
+    // A list of entry identifiers the server computed similarities for
+    let entryIDs: [UInt64]
+    // Metadata for each entry in the database
+    let entryMetadatas: [[UInt8]]
+}
+
+/// Distances from one or more query vector to the database rows.
+struct DatabaseDistances: Sendable {
+    /// The distance from each query vector (outer dimension) to each database row (inner dimension).
+    let distances: Array2d<Float>
+    // Identifier for each entry in the database.
+    let entryIDs: [UInt64]
+    // Metadata for each entry in the database.
+    let entryMetadatas: [[UInt8]]
+}

--- a/Tests/HomomorphicEncryptionTests/Array2dTests.swift
+++ b/Tests/HomomorphicEncryptionTests/Array2dTests.swift
@@ -16,6 +16,23 @@
 import XCTest
 
 class Array2dTests: XCTestCase {
+    func testInit() {
+        func runTest<T: FixedWidthInteger & Sendable>(_: T.Type) {
+            let data = [T](1...6)
+            let array = Array2d(data: data, rowCount: 3, columnCount: 2)
+
+            let data2d: [[T]] = [[1, 2], [3, 4], [5, 6]]
+            XCTAssertEqual(array, Array2d(data: data2d))
+        }
+
+        runTest(Int.self)
+        runTest(Int32.self)
+        runTest(Int32.self)
+        runTest(Int64.self)
+        runTest(UInt64.self)
+        runTest(DWUInt128.self)
+    }
+
     func testZeroAndZeroize() {
         func runTest<T: FixedWidthInteger & Sendable>(_: T.Type) {
             let data = [T](1...16)
@@ -112,5 +129,17 @@ class Array2dTests: XCTestCase {
 
         array.append(rows: Array(40..<56))
         XCTAssertEqual(array, Array2d(data: [Int](0..<56), rowCount: 7, columnCount: 8))
+    }
+
+    func testMap() {
+        let data = [Int](0..<32)
+        let array = Array2d(data: data, rowCount: 4, columnCount: 8)
+
+        let arrayPlus1 = array.map { UInt($0) + 1 }
+        let expected = Array2d(data: [UInt](1..<33), rowCount: 4, columnCount: 8)
+        XCTAssertEqual(arrayPlus1, expected)
+
+        let roundtripArray = arrayPlus1.map { Int($0 - 1) }
+        XCTAssertEqual(roundtripArray, array)
     }
 }

--- a/Tests/HomomorphicEncryptionTests/NttTests.swift
+++ b/Tests/HomomorphicEncryptionTests/NttTests.swift
@@ -52,8 +52,8 @@ final class NttTests: XCTestCase {
         precondition(evalData.count == rowCount)
         precondition(evalData[0].count == columnCount)
 
-        let coeffData = Array2d(data: coeffData.flatMap { $0 }, rowCount: rowCount, columnCount: columnCount)
-        let evalData = Array2d(data: evalData.flatMap { $0 }, rowCount: rowCount, columnCount: columnCount)
+        let coeffData = Array2d(data: coeffData)
+        let evalData = Array2d(data: evalData)
 
         let context = try PolyContext(degree: columnCount, moduli: moduli)
         let polyCoeff = PolyRq<T, Coeff>(context: context, data: coeffData)

--- a/Tests/HomomorphicEncryptionTests/RnsBaseConverterTests.swift
+++ b/Tests/HomomorphicEncryptionTests/RnsBaseConverterTests.swift
@@ -35,8 +35,7 @@ final class RnsBaseConverterTests: XCTestCase {
             let referenceX = (0..<degree).map { _ in T.DoubleWidth.random(in: 0..<q) }
             let rnsBaseConverter = try RnsBaseConverter<T>(from: inputContext, to: outputContext)
             let data = referenceX.map { bigInt in TestUtils.crtDecompose(value: bigInt, moduli: inputContext.moduli) }
-            let inputData = Array2d(data: data.flatMap { $0 }, rowCount: degree, columnCount: inputContext.moduli.count)
-                .transposed()
+            let inputData = Array2d(data: data).transposed()
 
             let input = PolyRq<T, Coeff>(context: inputContext, data: inputData)
             let output = try rnsBaseConverter.convertApproximate(poly: input)
@@ -80,7 +79,7 @@ final class RnsBaseConverterTests: XCTestCase {
             let poly: PolyRq<T, Coeff> = PolyRq.random(context: inputContext)
 
             let rnsBaseConverter = try RnsBaseConverter<T>(from: inputContext, to: outputContext)
-            let composed: [QuadWidth<T>] = try rnsBaseConverter.crtCompose(poly: poly, variableTime: true)
+            let composed: [QuadWidth<T>] = try rnsBaseConverter.crtCompose(poly: poly)
 
             for (coeffIndex, composed) in composed.enumerated() {
                 let roundTripValues = TestUtils.crtDecompose(value: composed, moduli: inputContext.moduli)

--- a/Tests/HomomorphicEncryptionTests/RnsToolTests.swift
+++ b/Tests/HomomorphicEncryptionTests/RnsToolTests.swift
@@ -82,8 +82,7 @@ final class RnsToolTests: XCTestCase {
 
             let referenceX = (0..<degree).map { _ in OctoWidth<T>.random(in: 0..<q) }
             let data = referenceX.map { bigInt in TestUtils.crtDecompose(value: bigInt, moduli: inputContext.moduli) }
-            let inputData = Array2d(data: data.flatMap { $0 }, rowCount: degree, columnCount: inputContext.moduli.count)
-                .transposed()
+            let inputData = Array2d(data: data).transposed()
 
             let input = PolyRq<T, Coeff>(context: inputContext, data: inputData)
             let output = try rnsTool.convertApproximateBskMTilde(poly: input)
@@ -177,8 +176,7 @@ final class RnsToolTests: XCTestCase {
 
             let referenceX = (0..<degree).map { _ in OctoWidth<T>.random(in: 0..<q) }
             let data = referenceX.map { bigInt in TestUtils.crtDecompose(value: bigInt, moduli: inputContext.moduli) }
-            let inputData = Array2d(data: data.flatMap { $0 }, rowCount: degree, columnCount: inputContext.moduli.count)
-                .transposed()
+            let inputData = Array2d(data: data).transposed()
             let input: PolyRq<T, Coeff> = PolyRq(context: inputContext, data: inputData)
             let output = try rnsTool.liftQToQBsk(poly: input)
 
@@ -232,11 +230,7 @@ final class RnsToolTests: XCTestCase {
                 value: bigInt,
                 moduli: rnsTool.qBskContext.moduli)
             }
-            let inputData = Array2d(
-                data: data.flatMap { $0 },
-                rowCount: degree,
-                columnCount: rnsTool.qBskContext.moduli.count)
-                .transposed()
+            let inputData = Array2d(data: data).transposed()
             let input: PolyRq<T, Coeff> = PolyRq(context: rnsTool.qBskContext, data: inputData)
             let output = try rnsTool.approximateFloor(poly: input)
 
@@ -284,8 +278,7 @@ final class RnsToolTests: XCTestCase {
 
             let referenceX = (0..<degree).map { _ in OctoWidth<T>.random(in: 0..<q) }
             let data = referenceX.map { bigInt in TestUtils.crtDecompose(value: bigInt, moduli: bskModuli) }
-            let inputData = Array2d(data: data.flatMap { $0 }, rowCount: degree, columnCount: bskModuli.count)
-                .transposed()
+            let inputData = Array2d(data: data).transposed()
 
             let input = PolyRq<T, Coeff>(context: bskContext, data: inputData)
             let output = try rnsTool.convertApproximateBskToQ(poly: input)

--- a/Tests/PrivateNearestNeighborsSearchTests/ClientTests.swift
+++ b/Tests/PrivateNearestNeighborsSearchTests/ClientTests.swift
@@ -1,0 +1,164 @@
+// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import HomomorphicEncryption
+@testable import PrivateNearestNeighborsSearch
+import TestUtilities
+import XCTest
+
+final class ClientTests: XCTestCase {
+    func testClientConfig() throws {
+        func runTest<Scheme: HeScheme>(for _: Scheme.Type) throws {
+            let plaintextModuli = try [
+                PredefinedRlweParameters.n_4096_logq_27_28_28_logt_16,
+                PredefinedRlweParameters.n_4096_logq_27_28_28_logt_17,
+            ].map { rlweParams in
+                try EncryptionParameters<Scheme>(from: rlweParams).plaintextModulus
+            }
+            // Check scaling factor increases as we add plaintext moduli.
+            let maxScalingFactor1 = ClientConfig<Scheme>.maxScalingFactor(
+                vectorDimension: 128,
+                distanceMetric: .cosineSimilarity,
+                plaintextModuli: Array(plaintextModuli.prefix(1)))
+            let maxScalingFactor2 = ClientConfig<Scheme>.maxScalingFactor(
+                vectorDimension: 128,
+                distanceMetric: .cosineSimilarity,
+                plaintextModuli: plaintextModuli)
+            XCTAssertGreaterThan(maxScalingFactor2, maxScalingFactor1)
+
+            XCTAssertNoThrow(
+                try ClientConfig<Scheme>(
+                    encryptionParams: EncryptionParameters(from: PredefinedRlweParameters.n_4096_logq_27_28_28_logt_17),
+                    scalingFactor: maxScalingFactor2,
+                    queryPacking: .denseRow,
+                    vectorDimension: 128,
+                    evaluationKeyConfig: EvaluationKeyConfiguration(),
+                    distanceMetric: .cosineSimilarity,
+                    extraPlaintextModuli: [plaintextModuli[1]]))
+        }
+
+        try runTest(for: Bfv<UInt32>.self)
+        try runTest(for: Bfv<UInt64>.self)
+    }
+
+    func testNormalizeRowsAndScale() throws {
+        struct TestCase<T: SignedScalarType> {
+            let scalingFactor: Float
+            let norm: Array2d<Float>.Norm
+            let input: [[Float]]
+            let normalized: [[Float]]
+            let scaled: [[Float]]
+            let rounded: [[T]]
+        }
+
+        func runTestCase<T: SignedScalarType>(testCase: TestCase<T>) throws {
+            let floatMatrix = Array2d<Float>(data: testCase.input)
+            let normalized = floatMatrix.normalizedRows(norm: testCase.norm)
+            for (normalized, expected) in zip(normalized.data, testCase.normalized.flatMap { $0 }) {
+                XCTAssertIsClose(normalized, expected)
+            }
+
+            let scaled = normalized.scaled(by: testCase.scalingFactor)
+            for (scaled, expected) in zip(scaled.data, testCase.scaled.flatMap { $0 }) {
+                XCTAssertIsClose(scaled, expected)
+            }
+            let rounded: Array2d<T> = scaled.rounded()
+            XCTAssertEqual(rounded.data, testCase.rounded.flatMap { $0 })
+        }
+
+        let testCases: [TestCase<Int32>] = [
+            TestCase(scalingFactor: 10.0,
+                     norm: Array2d<Float>.Norm.Lp(p: 1.0),
+                     input: [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+                     normalized: [[1.0 / 3.0, 2.0 / 3.0], [3.0 / 7.0, 4.0 / 7.0], [5.0 / 11.0, 6.0 / 11.0]],
+                     scaled: [[10.0 / 3.0, 20.0 / 3.0], [30.0 / 7.0, 40.0 / 7.0], [50.0 / 11.0, 60.0 / 11.0]],
+                     rounded: [[3, 7], [4, 6], [5, 5]]),
+            TestCase(scalingFactor: 100.0,
+                     norm: Array2d<Float>.Norm.Lp(p: 2.0),
+                     input: [[3.0, 4.0], [-5.0, 12.0]],
+                     normalized: [[3.0 / 5.0, 4.0 / 5.0], [-5.0 / 13.0, 12.0 / 13.0]],
+                     scaled: [[300.0 / 5.0, 400.0 / 5.0], [-500.0 / 13.0, 1200.0 / 13.0]],
+                     rounded: [[60, 80], [-38, 92]]),
+        ]
+        for testCase in testCases {
+            try runTestCase(testCase: testCase)
+        }
+    }
+
+    func testQuery() throws {
+        func runTest<Scheme: HeScheme>(for _: Scheme.Type) throws {
+            let degree = 512
+            let encryptionParams = try EncryptionParameters<Scheme>(
+                polyDegree: degree,
+                plaintextModulus: Scheme.Scalar.generatePrimes(
+                    significantBitCounts: [16],
+                    preferringSmall: true,
+                    nttDegree: degree)[0],
+                coefficientModuli: Scheme.Scalar.generatePrimes(
+                    significantBitCounts: [27, 28, 28],
+                    preferringSmall: false,
+                    nttDegree: degree),
+                errorStdDev: .stdDev32,
+                securityLevel: .unchecked)
+            XCTAssert(encryptionParams.supportsSimdEncoding)
+            let context = try Context<Scheme>(encryptionParameters: encryptionParams)
+            let vectorDimension = 32
+            let queryDimensions = try MatrixDimensions(rowCount: 1, columnCount: vectorDimension)
+
+            let encodeValues: [[Scheme.Scalar]] = increasingData(
+                dimensions: queryDimensions,
+                modulus: context.plaintextModulus)
+            let queryValues: Array2d<Float> = Array2d(data: encodeValues).map { value in Float(value) }
+            let secretKey = try context.generateSecretKey()
+            let scalingFactor = 100
+
+            for extraPlaintextModuli in try [[], Scheme.Scalar.generatePrimes(
+                significantBitCounts: [17],
+                preferringSmall: true, nttDegree: degree)]
+            {
+                let config = ClientConfig(
+                    encryptionParams: encryptionParams,
+                    scalingFactor: scalingFactor,
+                    queryPacking: .denseRow,
+                    vectorDimension: vectorDimension,
+                    evaluationKeyConfig: EvaluationKeyConfiguration(),
+                    distanceMetric: .cosineSimilarity,
+                    extraPlaintextModuli: extraPlaintextModuli)
+                let client = try Client(config: config)
+                let query = try client.generateQuery(vectors: queryValues, using: secretKey)
+                XCTAssertEqual(query.ciphertextMatrices.count, config.plaintextModuli.count)
+
+                let entryIds = [UInt64(42)]
+                let entryMetadatas = [42.littleEndianBytes]
+                let response = Response(
+                    ciphertextMatrices: query.ciphertextMatrices,
+                    entryIDs: entryIds, entryMetadatas: entryMetadatas)
+                let databaseDistances = try client.decrypt(response: response, using: secretKey)
+                XCTAssertEqual(databaseDistances.entryIDs, entryIds)
+                XCTAssertEqual(databaseDistances.entryMetadatas, entryMetadatas)
+
+                let scaledQuery: Array2d<Scheme.SignedScalar> = queryValues
+                    .normalizedRows(norm: Array2d<Float>.Norm.Lp(p: 2.0)).scaled(by: Float(config.scalingFactor))
+                    .rounded()
+                // Cosine similarity response returns result scaled by scalingFactor^2
+                let expectedDistances = scaledQuery.map { value in
+                    Float(value) / Float(config.scalingFactor * config.scalingFactor)
+                }
+                XCTAssertEqual(databaseDistances.distances, expectedDistances)
+            }
+        }
+        try runTest(for: Bfv<UInt32>.self)
+        try runTest(for: Bfv<UInt64>.self)
+    }
+}


### PR DESCRIPTION
Adds PrivateNearestNeighbhorsSearch Client, with a few changes along the way:

* Allow constant-time CRT composition when the composed modulus fits in a ScalarType, by:
  1) Creating a separate `crtComposer` (a more limited API than the messier `RnsTool`) . For now, it's `package`, but I figure we could make it `public` eventually.
  2) Generalizing some Scalar ops from `ScalarType` to `FixedWidthInteger & UnsignedInteger` 
 
* Reordered `crtCompose` loops -> ~2x speedup in `NoiseBudget` benchmarks.
Before
```

NoiseBudget Bfv<UInt32>
╒═══════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Metric                        │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═══════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Malloc (total) *              │    8209 │    8209 │    8209 │    8209 │    8209 │    8209 │    8209 │    3270 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Memory (resident peak) (M)    │      17 │      18 │      18 │      18 │      18 │      18 │      18 │    3270 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (wall clock) (μs) *      │     841 │     860 │     863 │     872 │     883 │     941 │    1066 │    3270 │
╘═══════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

NoiseBudget Bfv<UInt64>
╒═══════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Metric                        │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═══════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Malloc (total) *              │    8211 │    8211 │    8211 │    8211 │    8211 │    8211 │    8211 │    2703 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Memory (resident peak) (M)    │      24 │      25 │      25 │      25 │      25 │      25 │      25 │    2703 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (wall clock) (μs) *      │    1016 │    1040 │    1047 │    1065 │    1100 │    1176 │    1472 │    2703 │
╘═══════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```


After
```
NoiseBudget Bfv<UInt32>
╒═══════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Metric                        │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═══════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Malloc (total) *              │      17 │      17 │      17 │      17 │      17 │      17 │      17 │    9737 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Memory (resident peak) (M)    │      18 │      18 │      18 │      18 │      18 │      18 │      18 │    9737 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (wall clock) (μs) *      │     248 │     253 │     254 │     260 │     270 │     313 │    7228 │    9737 │
╘═══════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

NoiseBudget Bfv<UInt64>
╒═══════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Metric                        │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═══════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Malloc (total) *              │      19 │      19 │      19 │      19 │      19 │      19 │      19 │    5498 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Memory (resident peak) (M)    │      24 │      25 │      25 │      25 │      25 │      25 │      25 │    5498 │
├───────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (wall clock) (μs) *      │     486 │     490 │     498 │     501 │     506 │     531 │     674 │    5498 │
╘═══════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```
