### PR TITLE
Update protos for plaintextPacking renaming

### DIFF
--- a/Sources/PrivateNearestNeighborsSearchProtobuf/ConversionPnns.swift
+++ b/Sources/PrivateNearestNeighborsSearchProtobuf/ConversionPnns.swift
@@ -71,10 +71,10 @@ extension Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPacking {
     /// - Returns: The converted native type.
     /// - Throws: Error upon unsupported object.
     public func native() throws -> MatrixPacking {
-        guard let plaintextPackingType else {
-            throw ConversionError.unsetOneof(oneof: Self.self, field: \Self.plaintextPackingType)
+        guard let matrixPackingType else {
+            throw ConversionError.unsetOneof(oneof: Self.self, field: \Self.matrixPackingType)
         }
-        switch plaintextPackingType {
+        switch matrixPackingType {
         case .denseColumn:
             return MatrixPacking.denseColumn
         case .denseRow:
@@ -98,16 +98,15 @@ extension MatrixPacking {
             switch self {
             case .denseColumn:
                 let protoDenseColumn = Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPackingDenseColumn()
-                packing.plaintextPackingType = .denseColumn(protoDenseColumn)
+                packing.matrixPackingType = .denseColumn(protoDenseColumn)
             case .denseRow:
                 let protoDenseRow = Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPackingDenseRow()
-                packing.plaintextPackingType = .denseRow(protoDenseRow)
+                packing.matrixPackingType = .denseRow(protoDenseRow)
             case let .diagonal(babyStepGiantStep):
                 let diagonal = Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPackingDiagonal.with { diagonalPacking in
-                    diagonalPacking.babyStepGiantStep = babyStepGiantStep
-                        .proto()
+                    diagonalPacking.babyStepGiantStep = babyStepGiantStep.proto()
                 }
-                packing.plaintextPackingType = .diagonal(diagonal)
+                packing.matrixPackingType = .diagonal(diagonal)
             }
         }
     }

--- a/Sources/PrivateNearestNeighborsSearchProtobuf/generated/apple_swift_homomorphic_encryption_api_pnns_v1_pnns.pb.swift
+++ b/Sources/PrivateNearestNeighborsSearchProtobuf/generated/apple_swift_homomorphic_encryption_api_pnns_v1_pnns.pb.swift
@@ -55,15 +55,15 @@ public struct Apple_SwiftHomomorphicEncryption_Api_Pnns_V1_PNNSConfig: @unchecke
   /// Factor by which to scale floating-point entries to integers.
   public var scalingFactor: UInt64 = 0
 
-  /// Plaintext packing for the query.
-  public var plaintextPacking: Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPacking {
-    get {return _plaintextPacking ?? Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPacking()}
-    set {_plaintextPacking = newValue}
+  /// Packing for the query.
+  public var queryPacking: Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPacking {
+    get {return _queryPacking ?? Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPacking()}
+    set {_queryPacking = newValue}
   }
-  /// Returns true if `plaintextPacking` has been explicitly set.
-  public var hasPlaintextPacking: Bool {return self._plaintextPacking != nil}
-  /// Clears the value of `plaintextPacking`. Subsequent reads from it will return its default value.
-  public mutating func clearPlaintextPacking() {self._plaintextPacking = nil}
+  /// Returns true if `queryPacking` has been explicitly set.
+  public var hasQueryPacking: Bool {return self._queryPacking != nil}
+  /// Clears the value of `queryPacking`. Subsequent reads from it will return its default value.
+  public mutating func clearQueryPacking() {self._queryPacking = nil}
 
   /// Number of entries in each vector.
   public var vectorDimension: UInt32 = 0
@@ -83,7 +83,7 @@ public struct Apple_SwiftHomomorphicEncryption_Api_Pnns_V1_PNNSConfig: @unchecke
   public init() {}
 
   fileprivate var _encryptionParameters: HomomorphicEncryptionProtobuf.Apple_SwiftHomomorphicEncryption_V1_EncryptionParameters? = nil
-  fileprivate var _plaintextPacking: Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPacking? = nil
+  fileprivate var _queryPacking: Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPacking? = nil
 }
 
 /// PNNS Request
@@ -172,7 +172,7 @@ extension Apple_SwiftHomomorphicEncryption_Api_Pnns_V1_PNNSConfig: SwiftProtobuf
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "encryption_parameters"),
     2: .standard(proto: "scaling_factor"),
-    3: .standard(proto: "plaintext_packing"),
+    3: .standard(proto: "query_packing"),
     4: .standard(proto: "vector_dimension"),
     5: .standard(proto: "distance_metric"),
     6: .standard(proto: "evaluation_key_config_hash"),
@@ -187,7 +187,7 @@ extension Apple_SwiftHomomorphicEncryption_Api_Pnns_V1_PNNSConfig: SwiftProtobuf
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._encryptionParameters) }()
       case 2: try { try decoder.decodeSingularUInt64Field(value: &self.scalingFactor) }()
-      case 3: try { try decoder.decodeSingularMessageField(value: &self._plaintextPacking) }()
+      case 3: try { try decoder.decodeSingularMessageField(value: &self._queryPacking) }()
       case 4: try { try decoder.decodeSingularUInt32Field(value: &self.vectorDimension) }()
       case 5: try { try decoder.decodeSingularEnumField(value: &self.distanceMetric) }()
       case 6: try { try decoder.decodeSingularBytesField(value: &self.evaluationKeyConfigHash) }()
@@ -208,7 +208,7 @@ extension Apple_SwiftHomomorphicEncryption_Api_Pnns_V1_PNNSConfig: SwiftProtobuf
     if self.scalingFactor != 0 {
       try visitor.visitSingularUInt64Field(value: self.scalingFactor, fieldNumber: 2)
     }
-    try { if let v = self._plaintextPacking {
+    try { if let v = self._queryPacking {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     } }()
     if self.vectorDimension != 0 {
@@ -229,7 +229,7 @@ extension Apple_SwiftHomomorphicEncryption_Api_Pnns_V1_PNNSConfig: SwiftProtobuf
   public static func ==(lhs: Apple_SwiftHomomorphicEncryption_Api_Pnns_V1_PNNSConfig, rhs: Apple_SwiftHomomorphicEncryption_Api_Pnns_V1_PNNSConfig) -> Bool {
     if lhs._encryptionParameters != rhs._encryptionParameters {return false}
     if lhs.scalingFactor != rhs.scalingFactor {return false}
-    if lhs._plaintextPacking != rhs._plaintextPacking {return false}
+    if lhs._queryPacking != rhs._queryPacking {return false}
     if lhs.vectorDimension != rhs.vectorDimension {return false}
     if lhs.distanceMetric != rhs.distanceMetric {return false}
     if lhs.evaluationKeyConfigHash != rhs.evaluationKeyConfigHash {return false}

--- a/Sources/PrivateNearestNeighborsSearchProtobuf/generated/apple_swift_homomorphic_encryption_pnns_v1_pnns_matrix_packing.pb.swift
+++ b/Sources/PrivateNearestNeighborsSearchProtobuf/generated/apple_swift_homomorphic_encryption_pnns_v1_pnns_matrix_packing.pb.swift
@@ -62,15 +62,15 @@ public struct Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPacking: Sendable {
   // methods supported on all messages.
 
   /// Different packing formats.
-  public var plaintextPackingType: Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPacking.OneOf_PlaintextPackingType? = nil
+  public var matrixPackingType: Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPacking.OneOf_MatrixPackingType? = nil
 
   /// Dense row packing.
   public var denseRow: Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPackingDenseRow {
     get {
-      if case .denseRow(let v)? = plaintextPackingType {return v}
+      if case .denseRow(let v)? = matrixPackingType {return v}
       return Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPackingDenseRow()
     }
-    set {plaintextPackingType = .denseRow(newValue)}
+    set {matrixPackingType = .denseRow(newValue)}
   }
 
   //// Packs the values using a generalized diagonal packing.
@@ -79,10 +79,10 @@ public struct Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPacking: Sendable {
   //// <https://eprint.iacr.org/2018/244.pdf>.
   public var diagonal: Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPackingDiagonal {
     get {
-      if case .diagonal(let v)? = plaintextPackingType {return v}
+      if case .diagonal(let v)? = matrixPackingType {return v}
       return Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPackingDiagonal()
     }
-    set {plaintextPackingType = .diagonal(newValue)}
+    set {matrixPackingType = .diagonal(newValue)}
   }
 
   //// As many rows of data are packed sequentially into each SIMD plaintext
@@ -93,16 +93,16 @@ public struct Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPacking: Sendable {
   //// row are repeated.
   public var denseColumn: Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPackingDenseColumn {
     get {
-      if case .denseColumn(let v)? = plaintextPackingType {return v}
+      if case .denseColumn(let v)? = matrixPackingType {return v}
       return Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPackingDenseColumn()
     }
-    set {plaintextPackingType = .denseColumn(newValue)}
+    set {matrixPackingType = .denseColumn(newValue)}
   }
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Different packing formats.
-  public enum OneOf_PlaintextPackingType: Equatable, Sendable {
+  public enum OneOf_MatrixPackingType: Equatable, Sendable {
     /// Dense row packing.
     case denseRow(Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPackingDenseRow)
     //// Packs the values using a generalized diagonal packing.
@@ -239,40 +239,40 @@ extension Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPacking: SwiftProtobuf.
       case 1: try {
         var v: Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPackingDenseRow?
         var hadOneofValue = false
-        if let current = self.plaintextPackingType {
+        if let current = self.matrixPackingType {
           hadOneofValue = true
           if case .denseRow(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
         if let v = v {
           if hadOneofValue {try decoder.handleConflictingOneOf()}
-          self.plaintextPackingType = .denseRow(v)
+          self.matrixPackingType = .denseRow(v)
         }
       }()
       case 2: try {
         var v: Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPackingDiagonal?
         var hadOneofValue = false
-        if let current = self.plaintextPackingType {
+        if let current = self.matrixPackingType {
           hadOneofValue = true
           if case .diagonal(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
         if let v = v {
           if hadOneofValue {try decoder.handleConflictingOneOf()}
-          self.plaintextPackingType = .diagonal(v)
+          self.matrixPackingType = .diagonal(v)
         }
       }()
       case 3: try {
         var v: Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPackingDenseColumn?
         var hadOneofValue = false
-        if let current = self.plaintextPackingType {
+        if let current = self.matrixPackingType {
           hadOneofValue = true
           if case .denseColumn(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
         if let v = v {
           if hadOneofValue {try decoder.handleConflictingOneOf()}
-          self.plaintextPackingType = .denseColumn(v)
+          self.matrixPackingType = .denseColumn(v)
         }
       }()
       default: break
@@ -285,17 +285,17 @@ extension Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPacking: SwiftProtobuf.
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
     // https://github.com/apple/swift-protobuf/issues/1182
-    switch self.plaintextPackingType {
+    switch self.matrixPackingType {
     case .denseRow?: try {
-      guard case .denseRow(let v)? = self.plaintextPackingType else { preconditionFailure() }
+      guard case .denseRow(let v)? = self.matrixPackingType else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }()
     case .diagonal?: try {
-      guard case .diagonal(let v)? = self.plaintextPackingType else { preconditionFailure() }
+      guard case .diagonal(let v)? = self.matrixPackingType else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
     }()
     case .denseColumn?: try {
-      guard case .denseColumn(let v)? = self.plaintextPackingType else { preconditionFailure() }
+      guard case .denseColumn(let v)? = self.matrixPackingType else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     }()
     case nil: break
@@ -304,7 +304,7 @@ extension Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPacking: SwiftProtobuf.
   }
 
   public static func ==(lhs: Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPacking, rhs: Apple_SwiftHomomorphicEncryption_Pnns_V1_MatrixPacking) -> Bool {
-    if lhs.plaintextPackingType != rhs.plaintextPackingType {return false}
+    if lhs.matrixPackingType != rhs.matrixPackingType {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }


### PR DESCRIPTION
Update protos after https://github.com/apple/swift-homomorphic-encryption-protobuf/pull/12.