### PR TITLE
Faster bytesToCoefficientInplace -> faster deserialization

### DIFF
--- a/Sources/HomomorphicEncryption/Error.swift
+++ b/Sources/HomomorphicEncryption/Error.swift
@@ -28,6 +28,7 @@ public enum HeError: Error, Equatable {
     case insecureEncryptionParameters(_ description: String)
     case invalidCiphertext(_ description: String)
     case invalidCoefficientIndex(index: Int, degree: Int)
+    case invalidCoefficientPacking(bitsPerCoeff: Int, skipLSBs: Int)
     case invalidContext(_ description: String)
     case invalidCorrectionFactor(_ description: String)
     case invalidDegree(_ degree: Int)
@@ -203,6 +204,8 @@ extension HeError: LocalizedError {
             "Insecure encryption parameters \(description)"
         case let .invalidCoefficientIndex(index, degree):
             "Invalid coefficient index \(index) for degree \(degree)"
+        case let .invalidCoefficientPacking(bitsPerCoeff, skipLSBs):
+            "Invalid coefficint packing: bitsPerCoeff \(bitsPerCoeff), skipLSBs \(skipLSBs)"
         case let .invalidCiphertext(description):
             "\(description)"
         case let .invalidContext(description):

--- a/Sources/HomomorphicEncryption/HeScheme.swift
+++ b/Sources/HomomorphicEncryption/HeScheme.swift
@@ -1028,7 +1028,7 @@ extension HeScheme {
         }
 
         let galoisElements = Array(galoisKey.keys.keys)
-        let steps = try GaloisElement.stepsFor(elements: galoisElements, degree: degree).values.compactMap { $0 }
+        let steps = GaloisElement.stepsFor(elements: galoisElements, degree: degree).values.compactMap { $0 }
 
         let positiveStep = if step < 0 {
             step + degree / 2

--- a/Sources/HomomorphicEncryption/PolyRq/PolyRq+Serialize.swift
+++ b/Sources/HomomorphicEncryption/PolyRq/PolyRq+Serialize.swift
@@ -51,7 +51,7 @@ extension PolyRq {
             }
 
             let bytes = buffer[offset..<(offset &+ byteCount)]
-            CoefficientPacking.bytesToCoefficientsInplace(
+            try CoefficientPacking.bytesToCoefficientsInplace(
                 bytes: bytes,
                 coeffs: &data.data[polyIndices(rnsIndex: rnsIndex)],
                 bitsPerCoeff: bitsPerCoeff,

--- a/Sources/PrivateInformationRetrieval/MulPir.swift
+++ b/Sources/PrivateInformationRetrieval/MulPir.swift
@@ -453,7 +453,7 @@ extension MulPirServer {
                     return nil
                 }
                 let bytes = Array(entry[startIndex..<endIndex])
-                let coefficients: [Scheme.Scalar] = CoefficientPacking.bytesToCoefficients(
+                let coefficients: [Scheme.Scalar] = try CoefficientPacking.bytesToCoefficients(
                     bytes: bytes,
                     bitsPerCoeff: context.plaintextModulus.log2,
                     decode: false)
@@ -502,7 +502,7 @@ extension MulPirServer {
             .map { startIndex in
                 let endIndex = min(startIndex + bytesPerPlaintext, flatDatabase.count)
                 let values = Array(flatDatabase[startIndex..<endIndex])
-                let plaintextCoefficients: [Scheme.Scalar] = CoefficientPacking.bytesToCoefficients(
+                let plaintextCoefficients: [Scheme.Scalar] = try CoefficientPacking.bytesToCoefficients(
                     bytes: values,
                     bitsPerCoeff: context.plaintextModulus.log2,
                     decode: false)

--- a/Sources/PrivateInformationRetrieval/PirUtil.swift
+++ b/Sources/PrivateInformationRetrieval/PirUtil.swift
@@ -184,11 +184,11 @@ enum PirUtil<Scheme: HeScheme> {
         return try plaintexts.map { plaintext in try plaintext.encrypt(using: secretKey) }
     }
 
-    static func encodeDatabase<Scalar: ScalarType>(database: [[UInt8]], plaintextModulus: Scalar) -> [[Scalar]] {
-        database.map { entry in
-            CoefficientPacking.bytesToCoefficients(bytes: entry,
-                                                   bitsPerCoeff: plaintextModulus.log2,
-                                                   decode: false)
+    static func encodeDatabase<Scalar: ScalarType>(database: [[UInt8]], plaintextModulus: Scalar) throws -> [[Scalar]] {
+        try database.map { entry in
+            try CoefficientPacking.bytesToCoefficients(bytes: entry,
+                                                       bitsPerCoeff: plaintextModulus.log2,
+                                                       decode: false)
         }
     }
 }

--- a/Tests/HomomorphicEncryptionTests/CoefficientPackingTests.swift
+++ b/Tests/HomomorphicEncryptionTests/CoefficientPackingTests.swift
@@ -26,7 +26,7 @@ class CoefficientPackingTests: XCTestCase {
             var rng = NistAes128Ctr()
             rng.fill(&bytes)
 
-            let coeffs: [T] = CoefficientPacking.bytesToCoefficients(
+            let coeffs: [T] = try CoefficientPacking.bytesToCoefficients(
                 bytes: bytes,
                 bitsPerCoeff: log2t,
                 decode: false)
@@ -64,7 +64,7 @@ class CoefficientPackingTests: XCTestCase {
             }
 
             let bytes = try CoefficientPacking.coefficientsToBytes(coeffs: coeffs, bitsPerCoeff: log2t + 1)
-            let decodedCoeffs: [T] = CoefficientPacking.bytesToCoefficients(
+            let decodedCoeffs: [T] = try CoefficientPacking.bytesToCoefficients(
                 bytes: bytes,
                 bitsPerCoeff: log2t + 1,
                 decode: true)
@@ -76,7 +76,7 @@ class CoefficientPackingTests: XCTestCase {
         try runTest(UInt64.self)
     }
 
-    func testBytesToCoeffKAT() {
+    func testBytesToCoeffKAT() throws {
         struct BytesToCoeffKAT<T: ScalarType> {
             let bytes: [UInt8]
             let bitsPerCoeff: Int
@@ -85,7 +85,7 @@ class CoefficientPackingTests: XCTestCase {
             let expectedCoefficients: [T]
         }
 
-        func runTest<T: ScalarType>(_: T.Type) {
+        func runTest<T: ScalarType>(_: T.Type) throws {
             let kats: [BytesToCoeffKAT<T>] = [
                 BytesToCoeffKAT(
                     bytes: [3, 24, 95, 141, 179, 34, 113],
@@ -132,7 +132,7 @@ class CoefficientPackingTests: XCTestCase {
             ]
 
             for kat in kats {
-                let coeffs: [T] = CoefficientPacking.bytesToCoefficients(
+                let coeffs: [T] = try CoefficientPacking.bytesToCoefficients(
                     bytes: kat.bytes,
                     bitsPerCoeff: kat.bitsPerCoeff,
                     decode: kat.decode,
@@ -141,8 +141,8 @@ class CoefficientPackingTests: XCTestCase {
             }
         }
 
-        runTest(UInt32.self)
-        runTest(UInt64.self)
+        try runTest(UInt32.self)
+        try runTest(UInt64.self)
     }
 
     func testCoeffsToBytesKAT() throws {

--- a/Tests/HomomorphicEncryptionTests/PolyRqTests/GaloisTests.swift
+++ b/Tests/HomomorphicEncryptionTests/PolyRqTests/GaloisTests.swift
@@ -107,7 +107,7 @@ final class GaloisTests: XCTestCase {
     func testGaloisElementsToSteps() throws {
         let galoisElements = [2, 3, 9, 11]
         let degree = 8
-        let result = try GaloisElement.stepsFor(elements: galoisElements, degree: degree)
+        let result = GaloisElement.stepsFor(elements: galoisElements, degree: degree)
         let expected = [2: nil, 3: 3, 9: 2, 11: 1]
         XCTAssertEqual(result, expected)
 
@@ -119,7 +119,7 @@ final class GaloisTests: XCTestCase {
                 try elementToStep[GaloisElement.rotatingColumns(by: step, degree: degree)] = step
             }
 
-            let result = try GaloisElement.stepsFor(elements: Array(elementToStep.keys), degree: degree)
+            let result = GaloisElement.stepsFor(elements: Array(elementToStep.keys), degree: degree)
             XCTAssertEqual(result, elementToStep)
         }
     }


### PR DESCRIPTION
When converting bytes to coeffs, instead of parsing 1 byte at a time, we parse 8 bytes at a time as a UInt64. This gives a big speedup in deserialization.