### PR TITLE
Use Swift 6 for documentation

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -27,3 +27,4 @@ builder:
       - PrivateInformationRetrievalProtobuf
       - PrivateNearestNeighborsSearch
       - PrivateNearestNeighborsSearchProtobuf
+      swift_version: 6.0


### PR DESCRIPTION
The latest docc [build](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/builds) on `main` doesn't show any generated docs, likely due to the Swift 5.10 build failing. Let's try explicitly using swift 6 for the docs. 