### PR TITLE
Revert 'Adopt Swift 6'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ["6.0"]
+        swift: ["5.10", "6.0"]
     name: swift ${{ matrix.swift }} tests
     steps:
     - uses: slashmo/install-swift@v0.4.0

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "35058120a76c9add338a72688983f31eb5403042763150a08ca6e53652580567",
+  "originHash" : "8fa2cd62efd12ea7c4d07fe29cae38bf3817c0818b3db7d057d5cde48d63b525",
   "pins" : [
     {
       "identity" : "hdrhistogram-swift",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf",
       "state" : {
-        "revision" : "edb6ed4919f7756157fe02f2552b7e3850a538e5",
-        "version" : "1.28.1"
+        "revision" : "ebc7251dd5b37f627c93698e4374084d98409633",
+        "version" : "1.28.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 // Remember to update CI if changing
 
@@ -17,7 +17,9 @@
 // limitations under the License.
 import PackageDescription
 
-let librarySettings: [SwiftSetting] = []
+let librarySettings: [SwiftSetting] = [
+    .enableExperimentalFeature("StrictConcurrency"),
+]
 
 let executableSettings: [SwiftSetting] =
     librarySettings +
@@ -271,9 +273,7 @@ package.targets += [
         ]),
 ]
 
-#if canImport(Darwin)
 // Set the minimum macOS version for the package
 package.platforms = [
-    .macOS(.v15), // Constrained by Swift 6 support for Xcode (https://developer.apple.com/support/xcode/)
+    .macOS(.v14), // Constrained by Swift 5.10 support for Xcode (https://developer.apple.com/support/xcode/)
 ]
-#endif

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The PNNS implementation in Swift Homomorphic Encryption uses homomorphic encrypt
 Swift Homomorphic Encryption requires:
 * 64-bit processor with little-endian memory representation
 * macOS or Linux operating system
-* [Swift](https://www.swift.org/) version 6.0 or later
+* [Swift](https://www.swift.org/) version 5.10 or later
 
 > [!NOTE]
 > Swift Homomorphic Encryption relies on [SystemRandomNumberGenerator](https://developer.apple.com/documentation/swift/systemrandomnumbergenerator) as a cryptographically secure random number generator, which may have platform-dependent behavior.
@@ -134,7 +134,7 @@ swift run -c release EncryptionParametersSnippet
 ## Developing Swift Homomorphic Encryption
 ### Dependencies
 Building Swift Homomorphic Encryption requires:
-* [Swift](https://www.swift.org/) version 6.0 or later
+* [Swift](https://www.swift.org/) version 5.10 or later
 
 Additionally, developing Swift Homomorphic Encryption requires:
 * [Nick Lockwood SwiftFormat](https://github.com/nicklockwood/SwiftFormat), v0.54.0

--- a/Sources/HomomorphicEncryption/DoubleWidthUInt.swift
+++ b/Sources/HomomorphicEncryption/DoubleWidthUInt.swift
@@ -717,5 +717,6 @@ extension DoubleWidthUInt: UnsignedInteger where Base: FixedWidthInteger & Unsig
     }
 }
 
+@usableFromInline typealias DWUInt128 = DoubleWidthUInt<UInt64>
 @usableFromInline typealias QuadWidth<T: FixedWidthInteger & UnsignedInteger> = DoubleWidthUInt<DoubleWidthUInt<T>>
 @usableFromInline typealias OctoWidth<T: FixedWidthInteger & UnsignedInteger> = DoubleWidthUInt<QuadWidth<T>>

--- a/Sources/HomomorphicEncryption/HomomorphicEncryption.docc/UsingSwiftHomomorphicEncryption.md
+++ b/Sources/HomomorphicEncryption/HomomorphicEncryption.docc/UsingSwiftHomomorphicEncryption.md
@@ -6,7 +6,7 @@ Get started using Swift Homomorphic Encryption.
 Swift Homomorphic Encryption requires:
 * 64-bit processor with little-endian memory representation
 * macOS or Linux operating system
-* [Swift](https://www.swift.org/) version 6.0 or later
+* [Swift](https://www.swift.org/) version 5.10 or later
 
 > Note: Swift Homomorphic Encryption relies on [SystemRandomNumberGenerator](https://developer.apple.com/documentation/swift/systemrandomnumbergenerator) as a cryptographically secure random number generator, which may have platform-dependent behavior.
 

--- a/Sources/HomomorphicEncryption/PolyRq/PolyRq+Randomize.swift
+++ b/Sources/HomomorphicEncryption/PolyRq/PolyRq+Randomize.swift
@@ -53,7 +53,7 @@ extension PolyRq {
     @inlinable
     public mutating func randomizeUniform(using rng: inout some PseudoRandomNumberGenerator) {
         let chunkCount = min(degree, 1024)
-        let uint128ByteCount = MemoryLayout<UInt128>.size
+        let uint128ByteCount = MemoryLayout<DWUInt128>.size
         var randomBytes: [UInt8] = .init(repeating: 0, count: chunkCount * uint128ByteCount)
         // We can sample directly in Coeff or Eval domain
         for (rnsIndex, reduceModulus) in context.reduceModuliUInt64.enumerated() {
@@ -63,7 +63,7 @@ extension PolyRq {
                 for index in 0..<chunkCount {
                     // NOTE: for interoperability always ask rng for a UInt128 and reduces it
                     let u128 =
-                        UInt128(littleEndianBytes: randomBytes[index * uint128ByteCount..<(index + 1) *
+                        DWUInt128(littleEndianBytes: randomBytes[index * uint128ByteCount..<(index + 1) *
                                 uint128ByteCount])
                     let u64 = reduceModulus.reduce(u128)
                     self[offset + index] = T(u64)
@@ -92,7 +92,7 @@ extension PolyRq {
             // consumed for each coefficient.
             let u64: UInt64 = rng.next()
             let u32: UInt32 = rng.next()
-            let u128 = UInt128(u64) &<< 32 | UInt128(u32)
+            let u128 = DWUInt128(u64) &<< 32 | DWUInt128(u32)
 
             let val = T(reductionModulus.reduce(u128))
             for (index, modulus) in zip(rnsIndices(coeffIndex: coeffIndex), moduli) {

--- a/Sources/HomomorphicEncryption/Random/NistCtrDrbg.swift
+++ b/Sources/HomomorphicEncryption/Random/NistCtrDrbg.swift
@@ -24,23 +24,17 @@ import Foundation
 @usableFromInline
 package struct NistCtrDrbg {
     @usableFromInline static let ReseedInterval: Int64 = 1 << 48
-
     @usableFromInline static let MaxByteCountPerRequest: Int = 1 << 16
-
     /// Size of AES block.
     @usableFromInline static let BlockCount: Int = 16
-
     /// Size of AES key.
     @usableFromInline static let KeyCount: Int = 16
-
     /// Size of the seed.
     @usableFromInline static let SeedCount: Int = KeyCount + BlockCount
 
     @usableFromInline var key: SymmetricKey
-
     /// This is called `V` in the NIST specification.
-    @usableFromInline var nonce: UInt128
-
+    @usableFromInline var nonce: DWUInt128
     @usableFromInline var reseedCounter: Int64
 
     @usableFromInline var nonceBytes: [UInt8] {
@@ -76,7 +70,7 @@ package struct NistCtrDrbg {
 
         let zeroes = [UInt8](repeating: 0, count: requestedByteCount)
         let output = try AES._CTR.encrypt(zeroes, using: key, nonce: .init(nonceBytes: nonceBytes))
-        nonce &+= UInt128(requestedByteCount.dividingCeil(Self.BlockCount, variableTime: true))
+        nonce &+= DWUInt128(requestedByteCount.dividingCeil(Self.BlockCount, variableTime: true))
 
         let additionalInput = [UInt8](repeating: 0, count: Self.SeedCount)
         try ctrDrbgUpdate(providedData: additionalInput)

--- a/Sources/HomomorphicEncryption/Scalar.swift
+++ b/Sources/HomomorphicEncryption/Scalar.swift
@@ -108,7 +108,7 @@ extension UInt32: ScalarType {
 }
 
 extension UInt64: ScalarType {
-    public typealias DoubleWidth = UInt128
+    public typealias DoubleWidth = DoubleWidthUInt<UInt64>
     public typealias SignedScalar = Int64
 
     public static var rnsCorrectionFactor: UInt64 {
@@ -161,7 +161,7 @@ extension UInt64: DoubleWidthType {
     public typealias Scalar = UInt32
 }
 
-extension UInt128: DoubleWidthType {
+extension DWUInt128: DoubleWidthType {
     /// Single-width scalar, with bit-width half that of the ``DoubleWidthType``.
     public typealias Scalar = UInt64
 }

--- a/Sources/HomomorphicEncryption/Util.swift
+++ b/Sources/HomomorphicEncryption/Util.swift
@@ -25,6 +25,21 @@ extension Sequence where Element: Hashable {
     }
 }
 
+// https://github.com/swiftlang/swift-evolution/blob/main/proposals/0220-count-where.md
+// introduced in swift 6
+#if swift(<6.0)
+extension Sequence {
+    @inlinable
+    package func count(where predicate: (Element) throws -> Bool) rethrows -> Int {
+        var count = 0
+        for element in self where try predicate(element) {
+            count += 1
+        }
+        return count
+    }
+}
+#endif
+
 extension FixedWidthInteger {
     // not a constant time operation
     @inlinable

--- a/Sources/HomomorphicEncryptionProtobuf/MessageExtensions.swift
+++ b/Sources/HomomorphicEncryptionProtobuf/MessageExtensions.swift
@@ -24,7 +24,7 @@ extension Message {
     /// - Throws: Error upon failure to initialize message.
     public init(from path: String) throws {
         if path.hasSuffix(".txtpb") {
-            try self.init(textFormatString: String(contentsOfFile: path, encoding: .utf8))
+            try self.init(textFormatString: String(contentsOfFile: path))
         } else {
             let serializedData = try Data(contentsOf: URL(fileURLWithPath: path))
             try self.init(serializedBytes: serializedData)

--- a/Tests/HomomorphicEncryptionTests/Array2dTests.swift
+++ b/Tests/HomomorphicEncryptionTests/Array2dTests.swift
@@ -33,7 +33,7 @@ class Array2dTests: XCTestCase {
         runTest(Int32.self)
         runTest(Int64.self)
         runTest(UInt64.self)
-        runTest(UInt128.self)
+        runTest(DWUInt128.self)
     }
 
     func testZeroAndZeroize() {
@@ -54,7 +54,7 @@ class Array2dTests: XCTestCase {
         runTest(Int32.self)
         runTest(Int64.self)
         runTest(UInt64.self)
-        runTest(UInt128.self)
+        runTest(DWUInt128.self)
     }
 
     func testShape() {


### PR DESCRIPTION
Reverts https://github.com/apple/swift-homomorphic-encryption/pull/107.

Swift 6 adoption causes some issues :
* https://github.com/apple/live-caller-id-lookup-example/issues/36
* https://github.com/apple/live-caller-id-lookup-example/issues/34