### PR TITLE
Parallel PIRProcessDatabase

### DIFF
--- a/Sources/PrivateInformationRetrieval/KeywordDatabase.swift
+++ b/Sources/PrivateInformationRetrieval/KeywordDatabase.swift
@@ -148,7 +148,7 @@ extension Sharding {
 }
 
 /// A shard of a ``KeywordDatabase``.
-public struct KeywordDatabaseShard: Hashable, Codable {
+public struct KeywordDatabaseShard: Hashable, Codable, Sendable {
     /// Identifier for the shard.
     public let shardID: String
     /// Rows in the database.
@@ -204,7 +204,7 @@ extension KeywordDatabaseShard: Collection {
 }
 
 /// Configuration for a ``KeywordDatabase``.
-public struct KeywordDatabaseConfig: Hashable, Codable {
+public struct KeywordDatabaseConfig: Hashable, Codable, Sendable {
     public let sharding: Sharding
     public let keywordPirConfig: KeywordPirConfig
 
@@ -264,7 +264,7 @@ public struct KeywordDatabase {
 /// Utilities for processing a ``KeywordDatabase``.
 public enum ProcessKeywordDatabase {
     /// Arguments for processing a keyword database.
-    public struct Arguments<Scheme: HeScheme>: Codable {
+    public struct Arguments<Scheme: HeScheme>: Codable, Sendable {
         /// Database configuration.
         public let databaseConfig: KeywordDatabaseConfig
         /// Encryption parameters.

--- a/Sources/PrivateInformationRetrieval/KeywordPirProtocol.swift
+++ b/Sources/PrivateInformationRetrieval/KeywordPirProtocol.swift
@@ -16,7 +16,7 @@ import Foundation
 import HomomorphicEncryption
 
 /// Configuration for a ``KeywordDatabase``.
-public struct KeywordPirConfig: Hashable, Codable {
+public struct KeywordPirConfig: Hashable, Codable, Sendable {
     /// Number of dimensions in the database.
     @usableFromInline let dimensionCount: Int
 


### PR DESCRIPTION
**Asynchronous Processing:**
   - Converted `ProcessDatabase` to support asynchronous execution by utilizing `AsyncParsableCommand`.
   - Speeded up the execution of `PIRProcessDatabase` by adding asynchronous processing enabled through the `--parallel` flag with Swift concurrency. 
   Also added `Sendable` conformance to several types to ensure safe concurrent access.

**Enhanced Logging:**
   - Refined logging to include a prefix "Shard №\(shardID):" for each log entry. This change addresses the non-sequential and interleaved nature of logs caused by asynchronous execution, making it easier to trace shard-specific activities. 
   - Example log entries:
   `--no-parallel`: https://pastebin.com/gWH1n9B7
   `--parallel`: https://pastebin.com/QCrQMvJX
   
**Performance Comparison**, with 2 million numbers in identity.binpb:
- **Async Execution** (`time PIRProcessDatabase --parallel identity-config.json`):
   1: `real 0m11.638s, user 1m8.456s, sys 0m3.310s`
   2: `real 0m10.835s, user 1m8.368s, sys 0m3.242s`
   3: `real 0m10.833s, user 1m8.215s, sys 0m3.077s`

- **Sync Execution** (`time PIRProcessDatabase --no-parallel identity-config.json`):
   1: `real 0m52.301s, user 0m49.667s, sys 0m1.936s`
   2: `real 0m52.117s, user 0m49.544s, sys 0m1.961s`
   3: `real 0m51.489s, user 0m49.378s, sys 0m1.789s`

The asynchronous execution with `--parallel` demonstrates a significant reduction in real execution time compared to the synchronous approach.

P.S. identity-config.json:
```json
{
    "inputDatabase": "identity.binpb",
    "outputDatabase": "identity_data/identity/identity-SHARD_ID.bin",
    "outputPirParameters": "identity_data/identity/identity-SHARD_ID.params.txtpb",
    "rlweParameters": "n_4096_logq_27_28_28_logt_5",
    "sharding": {
        "shardCount": 20
    },
    "trialsPerShard": 1,
    "cuckooTableArguments": {
        "hashFunctionCount": 2,
        "maxEvictionCount": 100,
        "bucketCount": {
            "fixedSize": {
                "bucketCount": 10000
            }
        },
        "maxSerializedBucketSize": 1024
    }
}

```




