### PR TITLE
PIRProcessDatabase: fix response ciphertext count

### DIFF
--- a/Sources/PIRProcessDatabase/ProcessDatabase.swift
+++ b/Sources/PIRProcessDatabase/ProcessDatabase.swift
@@ -481,7 +481,8 @@ extension ProcessKeywordDatabase.ShardValidationResult {
             label: "keys"
         )
         descriptionDict["response size"] = try sizeString(byteCount: response.size(),
-                                                          count: response.ciphertexts.count, label: "ciphertexts")
+                                                          count: response.ciphertexts.flatMap { $0 }.count,
+                                                          label: "ciphertexts")
         descriptionDict["noise budget"] = String(format: "%.01f", noiseBudget)
 
         let runtimeString = computeTimes.sorted().map { runtime in


### PR DESCRIPTION
The response didn't take into account multiple ciphertexts for wide entries.