### PR TITLE
Inline plaintext and database deserialization

### DIFF
--- a/Benchmarks/RlweBenchmark/RlweBenchmark.swift
+++ b/Benchmarks/RlweBenchmark/RlweBenchmark.swift
@@ -412,6 +412,66 @@ func ciphertextSwapRowsBenchmark<Scheme: HeScheme>(_: Scheme.Type) -> () -> Void
     }
 }
 
+// MARK: Serialization
+
+func coeffPlaintextSerializeBenchmark<Scheme: HeScheme>(_: Scheme.Type) -> () -> Void {
+    {
+        benchmark("CoeffPlaintextSerialize", Scheme.self) { benchmark in
+            let benchmarkContext: RlweBenchmarkContext<Scheme> = try StaticRlweBenchmarkContext.getBenchmarkContext()
+            let plaintext = benchmarkContext.coeffPlaintext
+            benchmark.startMeasurement()
+            for _ in benchmark.scaledIterations {
+                blackHole(plaintext.serialize())
+            }
+        }
+    }
+}
+
+func evalPlaintextSerializeBenchmark<Scheme: HeScheme>(_: Scheme.Type) -> () -> Void {
+    {
+        benchmark("EvalPlaintextSerialize", Scheme.self) { benchmark in
+            let benchmarkContext: RlweBenchmarkContext<Scheme> = try StaticRlweBenchmarkContext.getBenchmarkContext()
+            let plaintext = benchmarkContext.evalPlaintext
+            benchmark.startMeasurement()
+            for _ in benchmark.scaledIterations {
+                blackHole(plaintext.serialize())
+            }
+        }
+    }
+}
+
+func coeffPlaintextDeserializeBenchmark<Scheme: HeScheme>(_: Scheme.Type) -> () -> Void {
+    {
+        benchmark("CoeffPlaintextDeserialize", Scheme.self) { benchmark in
+            let benchmarkContext: RlweBenchmarkContext<Scheme> = try StaticRlweBenchmarkContext.getBenchmarkContext()
+            let plaintext = benchmarkContext.coeffPlaintext
+            let serialized = plaintext.serialize()
+            benchmark.startMeasurement()
+            for _ in benchmark.scaledIterations {
+                try blackHole(_ = Scheme.CoeffPlaintext(
+                    deserialize: serialized,
+                    context: benchmarkContext.context))
+            }
+        }
+    }
+}
+
+func evalPlaintextDeserializeBenchmark<Scheme: HeScheme>(_: Scheme.Type) -> () -> Void {
+    {
+        benchmark("EvalPlaintextDeserialize", Scheme.self) { benchmark in
+            let benchmarkContext: RlweBenchmarkContext<Scheme> = try StaticRlweBenchmarkContext.getBenchmarkContext()
+            let plaintext = benchmarkContext.evalPlaintext
+            let serialized = plaintext.serialize()
+            benchmark.startMeasurement()
+            for _ in benchmark.scaledIterations {
+                try blackHole(_ = Scheme.EvalPlaintext(
+                    deserialize: serialized,
+                    context: benchmarkContext.context))
+            }
+        }
+    }
+}
+
 func ciphertextSerializeFullBenchmark<Scheme: HeScheme>(_: Scheme.Type) -> () -> Void {
     {
         benchmark("CiphertextSerializeFull", Scheme.self) { benchmark in
@@ -554,6 +614,16 @@ nonisolated(unsafe) let benchmarks: () -> Void = {
     ciphertextSwapRowsBenchmark(Bfv<UInt64>.self)()
 
     // Serialization
+    coeffPlaintextSerializeBenchmark(Bfv<UInt32>.self)()
+    coeffPlaintextSerializeBenchmark(Bfv<UInt64>.self)()
+    evalPlaintextSerializeBenchmark(Bfv<UInt32>.self)()
+    evalPlaintextSerializeBenchmark(Bfv<UInt64>.self)()
+
+    coeffPlaintextDeserializeBenchmark(Bfv<UInt32>.self)()
+    coeffPlaintextDeserializeBenchmark(Bfv<UInt64>.self)()
+    evalPlaintextDeserializeBenchmark(Bfv<UInt32>.self)()
+    evalPlaintextDeserializeBenchmark(Bfv<UInt64>.self)()
+
     ciphertextSerializeFullBenchmark(Bfv<UInt32>.self)()
     ciphertextSerializeFullBenchmark(Bfv<UInt64>.self)()
     ciphertextSerializeSeedBenchmark(Bfv<UInt32>.self)()

--- a/Sources/HomomorphicEncryption/SerializedPlaintext.swift
+++ b/Sources/HomomorphicEncryption/SerializedPlaintext.swift
@@ -37,6 +37,7 @@ extension Plaintext where Format == Coeff {
     ///   - serialized: Serialized plaintext.
     ///   - context: Context to associate with the plaintext.
     /// - Throws: Error upon failure to deserialize.
+    @inlinable
     public init(deserialize serialized: SerializedPlaintext, context: Context<Scheme>) throws {
         self.context = context
         self.poly = try PolyRq(deserialize: serialized.poly, context: context.plaintextContext)
@@ -51,6 +52,7 @@ extension Plaintext where Format == Eval {
     ///   - moduliCount: Optional number of moduli to associate with the plaintext. If not set, the plaintext will have
     /// the top-level ciphertext context with all the moduli.
     /// - Throws: Error upon failure to deserialize.
+    @inlinable
     public init(deserialize serialized: SerializedPlaintext, context: Context<Scheme>, moduliCount: Int? = nil) throws {
         self.context = context
         let moduliCount = moduliCount ?? context.ciphertextContext.moduli.count

--- a/Sources/PrivateInformationRetrieval/IndexPirProtocol.swift
+++ b/Sources/PrivateInformationRetrieval/IndexPirProtocol.swift
@@ -166,6 +166,7 @@ public struct ProcessedDatabase<Scheme: HeScheme>: Equatable, Sendable {
     ///   - path: Filepath storing serialized plaintexts.
     ///   - context: Context for HE computation.
     /// - Throws: Error upon failure to load the database.
+    @inlinable
     public init(from path: String, context: Context<Scheme>) throws {
         let loadedFile = try [UInt8](Data(contentsOf: URL(fileURLWithPath: path)))
         try self.init(from: loadedFile, context: context)
@@ -176,6 +177,7 @@ public struct ProcessedDatabase<Scheme: HeScheme>: Equatable, Sendable {
     ///   - buffer: Serialized plaintexts.
     ///   - context: Context for HE computation.
     /// - Throws: Error upon failure to deserialize.
+    @inlinable
     public init(from buffer: [UInt8], context: Context<Scheme>) throws {
         var offset = buffer.startIndex
         let versionNumber = buffer[offset]


### PR DESCRIPTION
Loading a processed PIR database is very slow, due to lack of specialization.
We add a few missing inlines.