### PR TITLE
Have docs point to 1.0.2 branch/webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,21 @@ Applications of Swift Homomorphic Encryption include:
 ## Overview
 Swift Homomorphic Encryption is a collection of libraries and executables.
 For more information, refer to documentation for the libraries:
-* [HomomorphicEncryptionProtobuf](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryptionprotobuf)
-* [HomomorphicEncryption](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption)
-* [PrivateInformationRetrievalProtobuf](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrievalprotobuf)
-* [PrivateInformationRetrieval](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrieval)
-* [PrivateNearestNeighborSearchProtobuf](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privatenearestneighborsearchprotobuf)
-* [PrivateNearestNeighborSearch](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privatenearestneighborsearch)
+* [HomomorphicEncryptionProtobuf](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/homomorphicencryptionprotobuf)
+* [HomomorphicEncryption](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/homomorphicencryption)
+* [PrivateInformationRetrievalProtobuf](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privateinformationretrievalprotobuf)
+* [PrivateInformationRetrieval](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privateinformationretrieval)
+* [PrivateNearestNeighborSearchProtobuf](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privatenearestneighborsearchprotobuf)
+* [PrivateNearestNeighborSearch](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privatenearestneighborsearch)
 
 and executables:
-* [PIRGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirgeneratedatabase)
-* [PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirprocessdatabase)
-* [PIRShardDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirsharddatabase)
-* [PNNSGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pnnsgeneratedatabase)
-* [PNNSProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pnnsprocessdatabase)
+* [PIRGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pirgeneratedatabase)
+* [PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pirprocessdatabase)
+* [PIRShardDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pirsharddatabase)
+* [PNNSGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pnnsgeneratedatabase)
+* [PNNSProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pnnsprocessdatabase)
 
-The documentation is hosted on the [Swift Package Index](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/documentation/homomorphicencryption).
+The documentation is hosted on the [Swift Package Index](https://swiftpackageindex.com/apple/swift-homomorphic-encryption).
 
 ## Background
 ### Homomorphic Encryption (HE)
@@ -121,7 +121,7 @@ You can then add
  ```
 to your Swift code to access the functionality in the `HomomorphicEncryption` library.
 
-See the example [Snippets](https://github.com/apple/swift-homomorphic-encryption/tree/main/Snippets) for examples of using `HomomorphicEncryption`.
+See the example [Snippets](https://github.com/apple/swift-homomorphic-encryption/tree/release/1.0/Snippets) for examples of using `HomomorphicEncryption`.
 To run the `EncryptionParametersSnippet` example, run
 ```
 swift run -c release EncryptionParametersSnippet

--- a/Sources/HomomorphicEncryption/HomomorphicEncryption.docc/HomomorphicEncryption.md
+++ b/Sources/HomomorphicEncryption/HomomorphicEncryption.docc/HomomorphicEncryption.md
@@ -5,19 +5,19 @@ Homomorphic Encryption (HE) enables computation on encrypted data.
 ## Overview
 Swift Homomorphic Encryption is a collection of libraries and executables implementing homomorphic encryption (HE) and applications, such as private information retrieval (PIR).
 For more information, refer to documentation for the libraries:
-* [HomomorphicEncryptionProtobuf](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryptionprotobuf)
-* [HomomorphicEncryption](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption)
-* [PrivateInformationRetrievalProtobuf](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrievalprotobuf)
-* [PrivateInformationRetrieval](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrieval)
-* [PrivateNearestNeighborSearchProtobuf](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privatenearestneighborsearchprotobuf)
-* [PrivateNearestNeighborSearch](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privatenearestneighborsearch)
+* [HomomorphicEncryptionProtobuf](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/homomorphicencryptionprotobuf)
+* [HomomorphicEncryption](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/homomorphicencryption)
+* [PrivateInformationRetrievalProtobuf](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privateinformationretrievalprotobuf)
+* [PrivateInformationRetrieval](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privateinformationretrieval)
+* [PrivateNearestNeighborSearchProtobuf](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privatenearestneighborsearchprotobuf)
+* [PrivateNearestNeighborSearch](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privatenearestneighborsearch)
 
 and executables:
-* [PIRGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirgeneratedatabase)
-* [PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirprocessdatabase)
-* [PIRShardDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirsharddatabase)
-* [PNNSGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pnnsgeneratedatabase)
-* [PNNSProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pnnsprocessdatabase)
+* [PIRGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pirgeneratedatabase)
+* [PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pirprocessdatabase)
+* [PIRShardDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pirsharddatabase)
+* [PNNSGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pnnsgeneratedatabase)
+* [PNNSProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pnnsprocessdatabase)
 
 ### Background
 Swift Homomorphic Encryption implements a special form of cryptography called homomorphic encryption (HE).

--- a/Sources/HomomorphicEncryption/HomomorphicEncryption.docc/UsingSwiftHomomorphicEncryption.md
+++ b/Sources/HomomorphicEncryption/HomomorphicEncryption.docc/UsingSwiftHomomorphicEncryption.md
@@ -48,7 +48,7 @@ to your Swift code to access the functionality in the `HomomorphicEncryption` li
 
 > Note:
 > If you are using Swift Homomorphic Encryption for research, please cite using the
-> [CITATION.cff](https://github.com/apple/swift-homomorphic-encryption/blob/main/CITATION.cff) file.
+> [CITATION.cff](https://github.com/apple/swift-homomorphic-encryption/blob/release/1.0/CITATION.cff) file.
 
 ### Examples
 We give a few examples for how to use ``HomomorphicEncryption``.

--- a/Sources/HomomorphicEncryptionProtobuf/HomomorphicEncryptionProtobuf.docc/HomomorphicEncryptionProtobuf.md
+++ b/Sources/HomomorphicEncryptionProtobuf/HomomorphicEncryptionProtobuf.docc/HomomorphicEncryptionProtobuf.md
@@ -1,11 +1,11 @@
 # ``HomomorphicEncryptionProtobuf``
 
-Protocol buffer support for [HomomorphicEncryption](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption)
+Protocol buffer support for [HomomorphicEncryption](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/homomorphicencryption)
 
 ## Overview
-`HomomorphicEncryptionProtobuf` contains supports for using [HomomorphicEncryption](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption) with [protocol buffers](https://protobuf.dev/), commonly referred to as `protobuf`.
+`HomomorphicEncryptionProtobuf` contains supports for using [HomomorphicEncryption](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/homomorphicencryption) with [protocol buffers](https://protobuf.dev/), commonly referred to as `protobuf`.
 This module contains:
 * the generated Swift code to use the protobuf types.
-* conversion between protobuf types and [HomomorphicEncryption](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption) runtime types.
+* conversion between protobuf types and [HomomorphicEncryption](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/homomorphicencryption) runtime types.
 
 The protobuf schemas are defined at [https://github.com/apple/swift-homomorphic-encryption-protobuf](https://github.com/apple/swift-homomorphic-encryption-protobuf).

--- a/Sources/PIRGenerateDatabase/PIRGenerateDatabase.docc/PIRGenerateDatabase.md
+++ b/Sources/PIRGenerateDatabase/PIRGenerateDatabase.docc/PIRGenerateDatabase.md
@@ -29,7 +29,7 @@ PIRGenerateDatabase \
 
 This will generate a database of 100 rows, with keywords 0 to 99, and each value repeating the keyword for 10 to 20 bytes.
 
-The database is a serialized [Apple_SwiftHomomorphicEncryption_Pir_V1_KeywordDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrievalprotobuf/apple_swifthomomorphicencryption_pir_v1_keyworddatabase).
+The database is a serialized [Apple_SwiftHomomorphicEncryption_Pir_V1_KeywordDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privateinformationretrievalprotobuf/apple_swifthomomorphicencryption_pir_v1_keyworddatabase).
 For readability, the `.txtpb` extension ensures the output database will be saved in protocol buffer text format.
 
 > Note: For a more compact format, use the `.binpb` extension to save the database in protocol buffer binary format.

--- a/Sources/PIRProcessDatabase/PIRProcessDatabase.docc/PIRProcessDatabase.md
+++ b/Sources/PIRProcessDatabase/PIRProcessDatabase.docc/PIRProcessDatabase.md
@@ -26,10 +26,10 @@ Run `PIRProcessDatabase --help` to get a sample JSON configuration.
 ### Required Configuration Parameters
 
 There are four required parameters:
-1. `rlweParameters` is one of the [PredefinedRlweParameters](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption/predefinedrlweparameters),
+1. `rlweParameters` is one of the [PredefinedRlweParameters](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/homomorphicencryption/predefinedrlweparameters),
 e.g., `n_4096_logq_27_28_28_logt_5`.
 2. `inputDatabase` is the path to the unprocessed input database. It must be a
-serialized [Apple_SwiftHomomorphicEncryption_Pir_V1_KeywordDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrievalprotobuf/apple_swifthomomorphicencryption_pir_v1_keyworddatabase).
+serialized [Apple_SwiftHomomorphicEncryption_Pir_V1_KeywordDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privateinformationretrievalprotobuf/apple_swifthomomorphicencryption_pir_v1_keyworddatabase).
 
 > Note: The `PIRGenerateDatabase` binary can be used to generate a sample database.
 
@@ -51,7 +51,7 @@ A minimal configuration sample is
 }
 ```
 The only required parameter variable which affects performance is
-`rlweParameters`. These parameters are picked from a set of [PredefinedRlweParameters](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption/predefinedrlweparameters).
+`rlweParameters`. These parameters are picked from a set of [PredefinedRlweParameters](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/homomorphicencryption/predefinedrlweparameters).
 RLWE parameters are defined by ring dimension `n`, a ciphertext modulus bit
 length `log q`, and plaintext modulus bit length, `log t`.
 

--- a/Sources/PIRProcessDatabase/PIRProcessDatabase.docc/ReusingPirParameters.md
+++ b/Sources/PIRProcessDatabase/PIRProcessDatabase.docc/ReusingPirParameters.md
@@ -84,7 +84,7 @@ There are a few ways to find a good `bucketCount`:
   If the processing throws a `PirError.failedToConstructCuckooTable` or logs `Failed to construct Cuckoo table`, this is an indication the chosen bucket count was too small.
   Choose larger `bucketCounts` until the processing works.
 
-* Add a callback to [ProcessKeywordDatabase.processShard](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrieval/processkeyworddatabase/processshard(shard:with:)).
+* Add a callback to [ProcessKeywordDatabase.processShard](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privateinformationretrieval/processkeyworddatabase/processshard(shard:with:)).
   This callback can be used to report the bucketCount after the cuckoo table was created.
 A sample callback is
 ```swift

--- a/Sources/PIRShardDatabase/PIRShardDatabase.docc/PIRShardDatabase.md
+++ b/Sources/PIRShardDatabase/PIRShardDatabase.docc/PIRShardDatabase.md
@@ -4,24 +4,24 @@ Keyword PIR database sharding
 
 ## Overview
 
-[PIRShardDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirsharddatabase) is an executable which divides a database into disjoint shards.
-Each resulting shard is suitable for processing with the [PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirprocessdatabase) executable.
+[PIRShardDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pirsharddatabase) is an executable which divides a database into disjoint shards.
+Each resulting shard is suitable for processing with the [PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pirprocessdatabase) executable.
 
 `PIRShardDatabase` supports two sharding settings:
 * `shardCount` randomly shards the database using the specified of shards.
 * `entryCountPerShard` shards the database using enough shards such that the average shard contains the specified number of entries.
 
 ### Requirements
-Build the [PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirprocessdatabase) executable by running:
+Build the [PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pirprocessdatabase) executable by running:
 ```sh
 swift build -c release --target PIRProcessDatabase
 ```
 The binary will be generated in `.build/release/PIRProcessDatabase`.
 
 For the example below, you'll also need to install the
-[PIRGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirgeneratedatabse)
+[PIRGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pirgeneratedatabse)
 executable in a similar manner as
-[PIRShardDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirsharddatabase).
+[PIRShardDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pirsharddatabase).
 
 ### Example
 

--- a/Sources/PNNSGenerateDatabase/PNNSGenerateDatabase.docc/PNNSGenerateDatabase.md
+++ b/Sources/PNNSGenerateDatabase/PNNSGenerateDatabase.docc/PNNSGenerateDatabase.md
@@ -5,7 +5,7 @@ Private Nearest Neighbor Search database generation
 ## Overview
 
 `PNNSGenerateDatabase` is an executable which generates a sample database for testing.
-The resulting database can be processed with the [PNNSProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pnnsprocessdatabase) executable.
+The resulting database can be processed with the [PNNSProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pnnsprocessdatabase) executable.
 
 ### Requirements
 First ensure sure that the `~/.swiftpm/bin` directory is on your `$PATH`.

--- a/Sources/PNNSProcessDatabase/PNNSProcessDatabase.docc/PNNSProcessDatabase.md
+++ b/Sources/PNNSProcessDatabase/PNNSProcessDatabase.docc/PNNSProcessDatabase.md
@@ -32,12 +32,12 @@ Run `PNNSProcessDatabase --help` to get a sample JSON configuration.
 #### Required Configuration Parameters
 
 There are three required parameters:
-1. `rlweParameters` is one of the [PredefinedRlweParameters](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption/predefinedrlweparameters),
+1. `rlweParameters` is one of the [PredefinedRlweParameters](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/homomorphicencryption/predefinedrlweparameters),
 e.g., `n_8192_logq_3x55_logt_30`.
 2. `inputDatabase` is the path to the unprocessed input database. It must be a
 serialized `Apple_SwiftHomomorphicEncryption_Pnns_V1_Database`.
 
-> Note: The [PNNSGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pnnsgeneratedatabase) binary can be used to generate a sample database.
+> Note: The [PNNSGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pnnsgeneratedatabase) binary can be used to generate a sample database.
 
 3. `outputDatabase` is the path to where the processed database will be
 written. This string should have extension either `.txtpb` or `.binpb`.
@@ -51,8 +51,8 @@ A minimal configuration sample is
 }
 ```
 The only required parameter variable which affects performance is
-`rlweParameters`. These parameters are picked from a set of [PredefinedRlweParameters](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption/predefinedrlweparameters).
-See the [EncryptionParameters snippet]( https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption/usingswifthomomorphicencryption#Encryption-Parameters) for more information on encryption parameters.
+`rlweParameters`. These parameters are picked from a set of [PredefinedRlweParameters](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/homomorphicencryption/predefinedrlweparameters).
+See the [EncryptionParameters snippet]( https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/homomorphicencryption/usingswifthomomorphicencryption#Encryption-Parameters) for more information on encryption parameters.
 
 For `batchSize: 1`, `n_4096_logq_27_28_28_logt_16` may be a good choice.
 For larger batch sizes, `n_8192_logq_3x55_logt_30` may be a good choice.
@@ -80,7 +80,7 @@ For each trial, a query is checked for correctness.
 
 ### Example
 
-Our example relies on the [PNNSGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pnnsgeneratedatabase) executable.
+Our example relies on the [PNNSGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pnnsgeneratedatabase) executable.
 To install it, run
 ```sh
 swift package experimental-install -c release --product PNNSGenerateDatabase

--- a/Sources/PrivateInformationRetrieval/PrivateInformationRetrieval.docc/EncodingPipeline.md
+++ b/Sources/PrivateInformationRetrieval/PrivateInformationRetrieval.docc/EncodingPipeline.md
@@ -5,7 +5,7 @@ Learn how to scale data encoding for Private Information Retrieval.
 ## Overview
 
 While
-[PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirprocessdatabase)
+[PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pirprocessdatabase)
 documentation shows how to process small datasets, this page should give you an idea how to process large datasets.
 
 We start by introducing the sharding function. Once a database has been sharded, each shard can be processed
@@ -16,13 +16,13 @@ To encode as fast as possible, one could have multiple nodes that shard slices o
 nodes will collect the rows from the sharding nodes. Once the whole dataset has been divided into shards, each node
 holding a completed shard worth of rows can start processing them. Each node will upload the processed shard & the
 resulting PIR parameters to shared storage. A post-processing job can merge all the PIR parameters to construct a
-[PIRConfig](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrievalprotobuf/apple_swifthomomorphicencryption_api_v1_pirconfig)
+[PIRConfig](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privateinformationretrievalprotobuf/apple_swifthomomorphicencryption_api_v1_pirconfig)
 protobuf message that contains a shared evaluation key configuration and configuration for every shard.
 
 ## Sharding function
 
 While we do offer sharding as a convenience feature in ``KeywordDatabase/init(rows:sharding:)`` and even as a binary
-([PIRShardDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirsharddatabase)),
+([PIRShardDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pirsharddatabase)),
 it might be beneficial to understand how the sharding actually works and to incorporate that directly into your encoding
 pipeline. In Swift you can use ``Swift/Array/shardIndex(shardCount:)``, implemented as follows:
 
@@ -84,5 +84,5 @@ let loadedProcessedDatabaseWithParameters = try pirParameters.native(database: p
 
 Each shard also contains its own evaluation key configuration. But to give a single evaluation key configuration to the
 PIR client, we need to merge the evaluation key configurations from all shards. For that we can use
-[union()](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption/swift/sequence/union())
+[union()](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/homomorphicencryption/swift/sequence/union())
 on a sequence of evaluation key configurations.

--- a/Sources/PrivateInformationRetrieval/PrivateInformationRetrieval.docc/ParameterTuning.md
+++ b/Sources/PrivateInformationRetrieval/PrivateInformationRetrieval.docc/ParameterTuning.md
@@ -10,7 +10,7 @@ Notably, Keyword PIR's server runtime is linear in the shard size,
 independent of the keyword size, and dependent on the value size.
 Large values, such as images, should be compressed when possible.
 Parameters are read in by a JSON file as described in-detail in
-[PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirprocessdatabase) documentation.
+[PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pirprocessdatabase) documentation.
 
 ```sh
 PIRProcessDatabase ~/config.json
@@ -35,7 +35,7 @@ PIRs automatically. For thin databases, smaller RLWE plaintexts in
 fits many buckets. Large plaintexts are more efficient for
 wide databases.
 
-Otherwise, the observed [noise budget](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/homomorphicencryption/ciphertext/noisebudget(using:variabletime:)) is an important parameter to track. If it is low,
+Otherwise, the observed [noise budget](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/homomorphicencryption/ciphertext/noisebudget(using:variabletime:)) is an important parameter to track. If it is low,
 then it is best to increase the ciphertext-to-plaintext modulus ratio.
 This can be done by either decreasing the plaintext modulus with the same ring dimension
 or increasing the ring dimension and ciphertext modulus while keeping the
@@ -58,9 +58,9 @@ larger computation times.
 ### Examples
 
 The examples rely on the
-[PIRGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirgeneratedatabase)
+[PIRGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pirgeneratedatabase)
 and
-[PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pirprocessdatabase)
+[PIRProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pirprocessdatabase)
 executables.
 
 #### Thin Database

--- a/Sources/PrivateInformationRetrievalProtobuf/PrivateInformationRetrievalProtobuf.docc/PrivateInformationRetrievalProtobuf.md
+++ b/Sources/PrivateInformationRetrievalProtobuf/PrivateInformationRetrievalProtobuf.docc/PrivateInformationRetrievalProtobuf.md
@@ -1,11 +1,11 @@
 # ``PrivateInformationRetrievalProtobuf``
 
-Protocol buffer support for [PrivateInformationRetrieval](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrieval)
+Protocol buffer support for [PrivateInformationRetrieval](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privateinformationretrieval)
 
 ## Overview
-`PrivateInformationRetrievalProtobuf` contains supports for using [PrivateInformationRetrieval](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrieval) with [protocol buffers](https://protobuf.dev/), commonly referred to as `protobuf`.
+`PrivateInformationRetrievalProtobuf` contains supports for using [PrivateInformationRetrieval](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privateinformationretrieval) with [protocol buffers](https://protobuf.dev/), commonly referred to as `protobuf`.
 This module contains:
 * the generated Swift code to use the protobuf types.
-* conversion between protobuf types and [PrivateInformationRetrieval](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privateinformationretrieval) runtime types.
+* conversion between protobuf types and [PrivateInformationRetrieval](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privateinformationretrieval) runtime types.
 
 The protobuf schemas are defined at [https://github.com/apple/swift-homomorphic-encryption-protobuf](https://github.com/apple/swift-homomorphic-encryption-protobuf).

--- a/Sources/PrivateNearestNeighborSearch/PrivateNearestNeighborSearch.docc/PrivateNearestNeighborSearch.md
+++ b/Sources/PrivateNearestNeighborSearch/PrivateNearestNeighborSearch.docc/PrivateNearestNeighborSearch.md
@@ -15,4 +15,4 @@ While this *trivial PNNS* protocol satisfies the privacy and correctness require
 
 The PNNS implementation in Swift Homomorphic Encryption uses homomorphic encryption to improve upon the trivial PNNS protocol.
 
-See documentation for [PNNSGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pnnsgeneratedatabase) and  [PNNSProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pnnsprocessdatabase) for more information.
+See documentation for [PNNSGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pnnsgeneratedatabase) and  [PNNSProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/pnnsprocessdatabase) for more information.

--- a/Sources/PrivateNearestNeighborSearchProtobuf/PrivateNearestNeighborSearchProtobuf.docc/PrivateNearestNeighborSearch.md
+++ b/Sources/PrivateNearestNeighborSearchProtobuf/PrivateNearestNeighborSearchProtobuf.docc/PrivateNearestNeighborSearch.md
@@ -1,11 +1,11 @@
 # ``PrivateNearestNeighborSearchProtobuf``
 
-Protocol buffer support for [PrivateNearestNeighborSearch](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privatenearestneighborsearch)
+Protocol buffer support for [PrivateNearestNeighborSearch](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privatenearestneighborsearch)
 
 ## Overview
-`PrivateNearestNeighborProtobuf` contains supports for using [PrivateNearestNeighborSearch](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privatenearestneighborsearch) with [protocol buffers](https://protobuf.dev/), commonly referred to as `protobuf`.
+`PrivateNearestNeighborProtobuf` contains supports for using [PrivateNearestNeighborSearch](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privatenearestneighborsearch) with [protocol buffers](https://protobuf.dev/), commonly referred to as `protobuf`.
 This module contains:
 * the generated Swift code to use the protobuf types.
-* conversion between protobuf types and [PrivateNearestNeighborSearch](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/privatenearestneighborsearch) runtime types.
+* conversion between protobuf types and [PrivateNearestNeighborSearch](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/1.0.2/documentation/privatenearestneighborsearch) runtime types.
 
 The protobuf schemas are defined at [https://github.com/apple/swift-homomorphic-encryption-protobuf](https://github.com/apple/swift-homomorphic-encryption-protobuf).


### PR DESCRIPTION
Have docs point to 1.0.2 branch/webpage instead of `main`, which could be out of date.