### PR TITLE
Run CI on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/**" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/**" ]
     types: [opened, reopened, synchronize, ready_for_review]
 # Pushing changes to PR stops currently-running CI
 concurrency:


### PR DESCRIPTION
Following example at https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#using-filters. Seems to work, based on https://github.com/apple/swift-homomorphic-encryption/pull/130 (which already has this change in a previous commit)