### PR TITLE
Update Swift Package Index link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ and executables:
 * [PNNSGenerateDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pnnsgeneratedatabase)
 * [PNNSProcessDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/pnnsprocessdatabase)
 
-The documentation is hosted on the [Swift Package Index](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/documentation/homomorphicencryption).
+The documentation is hosted on the [Swift Package Index](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/documentation).
 
 ## Background
 ### Homomorphic Encryption (HE)


### PR DESCRIPTION
https://github.com/apple/swift-homomorphic-encryption/pull/130 made this change, so we pull it into `main` as well.