### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,19 +33,22 @@ env:
 jobs:
   swift-tests:
     timeout-minutes: 15
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        swift: ["6.0"]
-    name: swift ${{ matrix.swift }} tests
+        swift_version: ['6.0']
+        os_version: ['jammy']
+    container:
+      image: swift:${{ matrix.swift_version }}-${{ matrix.os_version }}
+    name: swift ${{ matrix.swift_version }} tests
     steps:
-    - uses: slashmo/install-swift@v0.4.0
-      with:
-        version: ${{ matrix.swift }}
-    - uses: actions/checkout@v4
+    - name: Swift version
+      run: swift --version
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: Install jemalloc
-      run: sudo apt-get install -y libjemalloc-dev
+      run: apt-get update && apt-get install -y libjemalloc-dev
     - name: Run tests
       run: swift test --configuration release --parallel
     - name: Run snippets
@@ -58,7 +61,8 @@ jobs:
     timeout-minutes: 1
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: Install pre-commit
       run: pip install pre-commit
     - name: Pre-commit checks
@@ -71,7 +75,8 @@ jobs:
     timeout-minutes: 1
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
       with:
         fetch-depth: 2
     - name: Install pre-commit
@@ -84,7 +89,8 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: Cache SwiftLint
       id: cache-swiftlint
       uses: actions/cache@v4
@@ -101,7 +107,8 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: Cache SwiftFormat
       id: cache-swiftformat
       uses: actions/cache@v4
@@ -118,6 +125,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: Check documentation comments
       run: ci/run-apple-swift-format.sh


### PR DESCRIPTION
CI is failing (e.g. https://github.com/apple/swift-homomorphic-encryption/actions/runs/13637921034/job/38121049369#step:1:27) due to `slashmo` using a deprecated version of `actions/cache: v3.2.3`. So we remove the dependency on `slashmo`.