### PR TITLE
Fix linking to c_zeroize with Cxx mode (#153)

### DIFF
--- a/Sources/CUtil/zeroize.h
+++ b/Sources/CUtil/zeroize.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,12 @@
 
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 void c_zeroize(void *s, size_t n);
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEROIZE_H */


### PR DESCRIPTION
Backport https://github.com/apple/swift-homomorphic-encryption/pull/153 to `release/1.0` branch