### PR TITLE
Migrate ConversionTests and RandomTests to Swift Testing

### DIFF
--- a/Sources/HomomorphicEncryption/HeScheme.swift
+++ b/Sources/HomomorphicEncryption/HeScheme.swift
@@ -46,7 +46,7 @@ public final class Eval: PolyFormat {
 ///
 /// This differs from the ``PolyFormat``: while the ``PolyFormat`` specifies the representation of the polynomials, the
 /// encoding format specifies the computations performed on the underlying plaintext, during HE computation.
-public enum EncodeFormat: CaseIterable {
+public enum EncodeFormat: CaseIterable, Sendable {
     /// Element-wise encoding of coefficients.
     ///
     /// Plaintexts in ``coefficient`` format are encoded using ``Coeff`` format. Addition, subtraction, and negation to

--- a/Tests/HomomorphicEncryptionTests/RandomTests/BufferedRngTests.swift
+++ b/Tests/HomomorphicEncryptionTests/RandomTests/BufferedRngTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 @testable import HomomorphicEncryption
-import XCTest
+import Testing
 
-final class BufferedRngTests: XCTestCase {
+@Suite
+struct BufferedRngTests {
     private struct TestRng: PseudoRandomNumberGenerator {
         var counter: UInt8 = 0
 
@@ -27,39 +28,42 @@ final class BufferedRngTests: XCTestCase {
         }
     }
 
-    func testFill() {
+    @Test
+    func fill() {
         var bufferedRng = BufferedRng(rng: TestRng(), bufferCount: 2)
 
         var data = [UInt8](repeating: 0, count: 7)
         bufferedRng.fill(&data[0..<3])
 
-        XCTAssertEqual(data, [0, 1, 2, 0, 0, 0, 0])
-        XCTAssertEqual(bufferedRng.offset, 1)
-        XCTAssertEqual(bufferedRng.remaining, 1)
-        XCTAssertEqual(bufferedRng.array, [2, 3])
+        #expect(data == [0, 1, 2, 0, 0, 0, 0])
+        #expect(bufferedRng.offset == 1)
+        #expect(bufferedRng.remaining == 1)
+        #expect(bufferedRng.array == [2, 3])
 
         bufferedRng.fill(&data[...])
-        XCTAssertEqual(data, [3, 4, 5, 6, 7, 8, 9])
-        XCTAssertEqual(bufferedRng.offset, 2)
-        XCTAssertEqual(bufferedRng.remaining, 0)
-        XCTAssertEqual(bufferedRng.array, [8, 9])
+        #expect(data == [3, 4, 5, 6, 7, 8, 9])
+        #expect(bufferedRng.offset == 2)
+        #expect(bufferedRng.remaining == 0)
+        #expect(bufferedRng.array == [8, 9])
     }
 
-    func testNextFixedWidthInteger() {
+    @Test
+    func nextFixedWidthInteger() {
         var bufferedRng = BufferedRng(rng: TestRng(), bufferCount: 32)
 
-        XCTAssertEqual(bufferedRng.next(), UInt8(0))
-        XCTAssertEqual(bufferedRng.next(), UInt16(2 << 8 | 1))
-        XCTAssertEqual(bufferedRng.next(), UInt32(6 << 24 | 5 << 16 | 4 << 8 | 3))
+        #expect(bufferedRng.next() == UInt8(0))
+        #expect(bufferedRng.next() == UInt16(2 << 8 | 1))
+        #expect(bufferedRng.next() == UInt32(6 << 24 | 5 << 16 | 4 << 8 | 3))
         let _: UInt64 = bufferedRng.next()
-        XCTAssertEqual(bufferedRng.next(), UInt8(15))
+        #expect(bufferedRng.next() == UInt8(15))
     }
 
-    func testFixedWidthFill() {
+    @Test
+    func fixedWidthFill() {
         var bufferedRng = BufferedRng(rng: TestRng(), bufferCount: 32)
         var buffer = [UInt16](repeating: 0, count: 3)
         bufferedRng.fill(&buffer[...])
-        XCTAssertEqual(buffer, [256, 770, 1284])
+        #expect(buffer == [256, 770, 1284])
     }
 }
 

--- a/Tests/HomomorphicEncryptionTests/RandomTests/NistCtrDrbgTests.swift
+++ b/Tests/HomomorphicEncryptionTests/RandomTests/NistCtrDrbgTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,16 +13,18 @@
 // limitations under the License.
 
 @testable import HomomorphicEncryption
+import Testing
 import TestUtilities
-import XCTest
 
-final class NistCtrDrbgTests: XCTestCase {
-    func testVector() throws {
+@Suite
+struct NistCtrDrbgTests {
+    @Test
+    func vector() throws {
         // Test vectors adapted from:
         // https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/random-number-generators
         let entropy =
-            try XCTUnwrap(Array(hexEncoded: "69a09f6bf5dda15cd4af29e14cf5e0cddd7d07ac39bba587f8bc331104f9c448"))
-        let expected = try XCTUnwrap(Array(hexEncoded:
+            try #require(Array(hexEncoded: "69a09f6bf5dda15cd4af29e14cf5e0cddd7d07ac39bba587f8bc331104f9c448"))
+        let expected = try #require(Array(hexEncoded:
             """
             f78a4919a6ec899f7b6c69381febbbe083315f3d289e70346db0e4ec4360473ae0b3\
             d916e9b6b964309f753ed66ae59de48da316cc1944bc8dfd0e2575d0ff6d
@@ -30,29 +32,30 @@ final class NistCtrDrbgTests: XCTestCase {
 
         var prng = try NistCtrDrbg(entropy: entropy)
 
-        func assertKey(_ hexString: String) {
+        func expectKey(_ hexString: String) {
             prng.key.withUnsafeBytes { keyBytes in
                 let data = Array(keyBytes)
-                XCTAssertEqual(data.hexEncodedString(), hexString)
+                #expect(data.hexEncodedString() == hexString)
             }
         }
 
-        func assertNonce(_ hexString: String) {
-            XCTAssertEqual(Array(prng.nonce.bigEndianBytes).hexEncodedString(), hexString)
+        func expectNonce(_ hexString: String) {
+            #expect(Array(prng.nonce.bigEndianBytes).hexEncodedString() == hexString)
         }
 
-        assertKey("314263a50fa3913de2d034b6e812a597")
-        assertNonce("def5dd62590d06150b94f1a8754b3a30")
+        expectKey("314263a50fa3913de2d034b6e812a597")
+        expectNonce("def5dd62590d06150b94f1a8754b3a30")
         _ = try prng.ctrDrbgGenerate(count: expected.count)
-        assertKey("4b0f2ae7d0b330fa709b0844c7eedb5c")
-        assertNonce("dae190eb55353de50e494cdef2a544d4")
+        expectKey("4b0f2ae7d0b330fa709b0844c7eedb5c")
+        expectNonce("dae190eb55353de50e494cdef2a544d4")
         let output = try prng.ctrDrbgGenerate(count: expected.count)
-        assertKey("b4d5d6de074612076e496f241ebcf017")
-        assertNonce("034eeae49adbdfccff79bfdc0d83ed70")
-        XCTAssertEqual(output, expected)
+        expectKey("b4d5d6de074612076e496f241ebcf017")
+        expectNonce("034eeae49adbdfccff79bfdc0d83ed70")
+        #expect(output == expected)
     }
 
-    func testVectors() throws {
+    @Test
+    func vectors() throws {
         // (entropy, returnedbits)
         let vectors = [
             (
@@ -148,13 +151,13 @@ final class NistCtrDrbgTests: XCTestCase {
         ]
 
         for (entropyString, outputString) in vectors {
-            let entropy = try XCTUnwrap(Array(hexEncoded: entropyString))
-            let expected = try XCTUnwrap(Array(hexEncoded: outputString))
+            let entropy = try #require(Array(hexEncoded: entropyString))
+            let expected = try #require(Array(hexEncoded: outputString))
 
             var prng = try NistCtrDrbg(entropy: entropy)
             _ = try prng.ctrDrbgGenerate(count: expected.count)
             let output = try prng.ctrDrbgGenerate(count: expected.count)
-            XCTAssertEqual(output, expected)
+            #expect(output == expected)
         }
     }
 }

--- a/Tests/HomomorphicEncryptionTests/RandomTests/PseudoRandomNumberGeneratorTests.swift
+++ b/Tests/HomomorphicEncryptionTests/RandomTests/PseudoRandomNumberGeneratorTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,23 +13,25 @@
 // limitations under the License.
 
 @testable import HomomorphicEncryption
+import Testing
 import TestUtilities
-import XCTest
 
-final class PseudoRandomNumberGeneratorTests: XCTestCase {
-    func testRandomNumberGeneratorFill() {
+@Suite
+struct PseudoRandomNumberGeneratorTests {
+    @Test
+    func randomNumberGeneratorFill() {
         var rng = TestUtilities.TestRng(counter: 0x8899_AABB_CCDD_EEFF)
         var buffer = [UInt8](repeating: 0, count: 10)
         rng.fill(&buffer)
-        XCTAssertEqual(buffer, [0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88, 0x00, 0xEF])
-        XCTAssertEqual(rng.next(), UInt32(0xCCDD_EF01))
+        #expect(buffer == [0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88, 0x00, 0xEF])
+        #expect(rng.next() == UInt32(0xCCDD_EF01))
 
         var exactBuffer = [UInt8](repeating: 0, count: 8)
         rng.fill(&exactBuffer)
-        XCTAssertEqual(exactBuffer, [0x02, 0xEF, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88])
+        #expect(exactBuffer == [0x02, 0xEF, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88])
 
         exactBuffer = [UInt8](repeating: 0, count: 7)
         rng.fill(&exactBuffer)
-        XCTAssertEqual(exactBuffer, [0x03, 0xEF, 0xDD, 0xCC, 0xBB, 0xAA, 0x99])
+        #expect(exactBuffer == [0x03, 0xEF, 0xDD, 0xCC, 0xBB, 0xAA, 0x99])
     }
 }


### PR DESCRIPTION
See #142 

`EncodeFormat` must be marked as `Sendable` to be used in parameterized tests