### PR TITLE
Avoid --test-bundle-path bug in unit-tests.

### DIFF
--- a/Sources/PIRGenerateDatabase/main.swift
+++ b/Sources/PIRGenerateDatabase/main.swift
@@ -24,6 +24,8 @@ enum ValueTypeArguments: String, CaseIterable, ExpressibleByArgument {
     case repeated
 }
 
+// This executable is used in tests, which breaks `swift test -c release` when used with `@main`.
+// So we avoid using `@main` here.
 struct ValueSizeArguments: ExpressibleByArgument {
     let range: Range<Int>
 
@@ -57,7 +59,6 @@ extension [UInt8] {
     }
 }
 
-@main
 struct GenerateDatabaseCommand: ParsableCommand {
     static let configuration: CommandConfiguration = .init(
         commandName: "PIRGenerateDatabase", version: Version.current.description)
@@ -97,3 +98,5 @@ struct GenerateDatabaseCommand: ParsableCommand {
         try databaseRows.proto().save(to: outputDatabase)
     }
 }
+
+GenerateDatabaseCommand.main()

--- a/Sources/PIRProcessDatabase/main.swift
+++ b/Sources/PIRProcessDatabase/main.swift
@@ -334,7 +334,8 @@ struct ResolvedArguments: CustomStringConvertible, Encodable {
     }
 }
 
-@main
+// This executable is used in tests, which breaks `swift test -c release` when used with `@main`.
+// So we avoid using `@main` here.
 struct ProcessDatabase: AsyncParsableCommand {
     static let configuration: CommandConfiguration = .init(
         commandName: "PIRProcessDatabase", version: Version.current.description)
@@ -549,3 +550,5 @@ extension Duration {
         Double(components.seconds) * 1e3 + Double(components.attoseconds) * 1e-15
     }
 }
+
+ProcessDatabase.main()


### PR DESCRIPTION
Executables used in unit tests are sometimes called with '--test-bundle-path' argument. We work around this by avoiding `@main` in those executables.