### PR TITLE
Make benchmarking opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ concurrency:
 env:
   SWIFTLINT_VERSION: 0.57.0
   SWIFTFORMAT_VERSION: 0.54.6
+  SWIFT_HOMOMORPHIC_ENCRYPTION_ENABLE_BENCHMARKING: 1
 jobs:
   swift-tests:
     timeout-minutes: 15

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,5 @@ Welcome to the Swift Homomorphic Encryption community! Thanks for your interest 
 ### Pull Requests:
 Before making a commit for a pull request, please run `pre-commit install`.
 Then on each commit some basic formatting checks will be run.
+
+Please also [enable benchmarking](README.md#Benchmarking).

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "00f869e23177fe695dd8283cb0093109907f008463129cf1e765a22549e2a3cb",
+  "originHash" : "ced990d8597aba5c797483ce88b32517f810f2b166b46e12d625160c7c0d0447",
   "pins" : [
     {
       "identity" : "hdrhistogram-swift",
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "45305d32cfb830faebcaa9a7aea66ad342637518",
-        "version" : "3.11.1"
+        "revision" : "a6ce32a18b81b04ce7e897d1d98df6eb2da04786",
+        "version" : "3.12.2"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
-        "version" : "1.6.2"
+        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
+        "version" : "1.6.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Foundation
 import PackageDescription
 
 let librarySettings: [SwiftSetting] = []
@@ -227,71 +228,81 @@ let package = Package(
 
 // MARK: - Benchmarks
 
-package.dependencies += [
-    .package(url: "https://github.com/ordo-one/package-benchmark", .upToNextMajor(from: "1.4.0")),
-]
-package.products += [.library(name: "_BenchmarkUtilities", targets: ["_BenchmarkUtilities"])]
-package.targets += [
-    .target(
-        name: "_BenchmarkUtilities",
-        dependencies: [
-            .product(name: "Benchmark", package: "package-benchmark"),
-            "HomomorphicEncryption",
-            "HomomorphicEncryptionProtobuf",
-            "PrivateInformationRetrieval",
-            "PrivateInformationRetrievalProtobuf",
-            "PrivateNearestNeighborSearch",
-            "PrivateNearestNeighborSearchProtobuf",
-        ],
-        path: "Sources/BenchmarkUtilities",
-        swiftSettings: benchmarkSettings),
-    .executableTarget(
-        name: "PolyBenchmark",
-        dependencies: [
-            .product(name: "Benchmark", package: "package-benchmark"),
-            "HomomorphicEncryption",
-        ],
-        path: "Benchmarks/PolyBenchmark",
-        swiftSettings: benchmarkSettings,
-        plugins: [
-            .plugin(name: "BenchmarkPlugin", package: "package-benchmark"),
-        ]),
-    .executableTarget(
-        name: "RlweBenchmark",
-        dependencies: [
-            .product(name: "Benchmark", package: "package-benchmark"),
-            "HomomorphicEncryption",
-        ],
-        path: "Benchmarks/RlweBenchmark",
-        swiftSettings: benchmarkSettings,
-        plugins: [
-            .plugin(name: "BenchmarkPlugin", package: "package-benchmark"),
-        ]),
-    .executableTarget(
-        name: "PIRBenchmark",
-        dependencies: [
-            .product(name: "Benchmark", package: "package-benchmark"),
-            "HomomorphicEncryption",
-            "_BenchmarkUtilities",
-        ],
-        path: "Benchmarks/PrivateInformationRetrievalBenchmark",
-        swiftSettings: benchmarkSettings,
-        plugins: [
-            .plugin(name: "BenchmarkPlugin", package: "package-benchmark"),
-        ]),
-    .executableTarget(
-        name: "PNNSBenchmark",
-        dependencies: [
-            .product(name: "Benchmark", package: "package-benchmark"),
-            "HomomorphicEncryption",
-            "_BenchmarkUtilities",
-        ],
-        path: "Benchmarks/PrivateNearestNeighborSearchBenchmark",
-        swiftSettings: benchmarkSettings,
-        plugins: [
-            .plugin(name: "BenchmarkPlugin", package: "package-benchmark"),
-        ]),
-]
+var enableBenchmarking: Bool {
+    let benchmarkFlags = "SWIFT_HOMOMORPHIC_ENCRYPTION_ENABLE_BENCHMARKING"
+    if let flag = ProcessInfo.processInfo.environment[benchmarkFlags], flag == "1" {
+        return true
+    }
+    return false
+}
+
+if enableBenchmarking {
+    package.dependencies += [
+        .package(url: "https://github.com/ordo-one/package-benchmark", .upToNextMajor(from: "1.4.0")),
+    ]
+    package.products += [.library(name: "_BenchmarkUtilities", targets: ["_BenchmarkUtilities"])]
+    package.targets += [
+        .target(
+            name: "_BenchmarkUtilities",
+            dependencies: [
+                .product(name: "Benchmark", package: "package-benchmark"),
+                "HomomorphicEncryption",
+                "HomomorphicEncryptionProtobuf",
+                "PrivateInformationRetrieval",
+                "PrivateInformationRetrievalProtobuf",
+                "PrivateNearestNeighborSearch",
+                "PrivateNearestNeighborSearchProtobuf",
+            ],
+            path: "Sources/BenchmarkUtilities",
+            swiftSettings: benchmarkSettings),
+        .executableTarget(
+            name: "PolyBenchmark",
+            dependencies: [
+                .product(name: "Benchmark", package: "package-benchmark"),
+                "HomomorphicEncryption",
+            ],
+            path: "Benchmarks/PolyBenchmark",
+            swiftSettings: benchmarkSettings,
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "package-benchmark"),
+            ]),
+        .executableTarget(
+            name: "RlweBenchmark",
+            dependencies: [
+                .product(name: "Benchmark", package: "package-benchmark"),
+                "HomomorphicEncryption",
+            ],
+            path: "Benchmarks/RlweBenchmark",
+            swiftSettings: benchmarkSettings,
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "package-benchmark"),
+            ]),
+        .executableTarget(
+            name: "PIRBenchmark",
+            dependencies: [
+                .product(name: "Benchmark", package: "package-benchmark"),
+                "HomomorphicEncryption",
+                "_BenchmarkUtilities",
+            ],
+            path: "Benchmarks/PrivateInformationRetrievalBenchmark",
+            swiftSettings: benchmarkSettings,
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "package-benchmark"),
+            ]),
+        .executableTarget(
+            name: "PNNSBenchmark",
+            dependencies: [
+                .product(name: "Benchmark", package: "package-benchmark"),
+                "HomomorphicEncryption",
+                "_BenchmarkUtilities",
+            ],
+            path: "Benchmarks/PrivateNearestNeighborSearchBenchmark",
+            swiftSettings: benchmarkSettings,
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "package-benchmark"),
+            ]),
+    ]
+}
 
 // Set the minimum macOS version for the package
 #if canImport(Darwin)

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ swift test --parallel
 
 ### Benchmarking
 Swift homomorphic encryption uses [Benchmark](https://github.com/ordo-one/package-benchmark) for benchmarking.
+To enable benchmarking, set the environment variable `SWIFT_HOMOMORPHIC_ENCRYPTION_ENABLE_BENCHMARKING=1`.
 By default, benchmarking requires the [jemalloc](http://jemalloc.net) dependency.
 
 > [!WARNING]


### PR DESCRIPTION
Right now, if we don't have `jemalloc` installed, we run into errors when running `swift build -c release` (see below).
So we add an environment flag `SWIFT_HOMOMORPHIC_ENCRYPTION_ENABLE_BENCHMARKING` to enable benchmarking. Once package-benchmark may remove the jemalloc dependency, https://github.com/ordo-one/package-benchmark/issues/318, we can probably remove this flag.
I figure until then, we should have a better out-of-the-box experience.

-----------
```
warning: you may be able to install jemalloc using your system-packager:
    brew install jemalloc
warning: you may be able to install jemalloc using your system-packager:
    brew install jemalloc
[1/1] Planning build
Building for production...
<module-includes>:1:9: note: in file included from <module-includes>:1:
1 | #import "../../Headers/jemalloc.h"
  |         `- note: in file included from <module-includes>:1:
2 |

/Users/fabianboemer/repos/swift-homomorphic-encryption/.build/checkouts/package-jemalloc/Sources/jemalloc/../../Headers/jemalloc.h:1:10: error: 'jemalloc/jemalloc.h' file not found
1 | #include <jemalloc/jemalloc.h>
  |          `- error: 'jemalloc/jemalloc.h' file not found
2 |

/Users/fabianboemer/repos/swift-homomorphic-encryption/.build/checkouts/package-benchmark/Sources/Benchmark/MallocStats/MallocStatsProducer+jemalloc.swift:14:12: error: could not build Objective-C module 'jemalloc'
 12 |
 13 | #if canImport(jemalloc)
 14 |     import jemalloc
    |            `- error: could not build Objective-C module 'jemalloc'
 15 |
 16 |     // We currently register a number of MIB:s that aren't in use that```
```