### PR TITLE
PIRProcessDatabase fix argument handling

### DIFF
--- a/Sources/PIRGenerateDatabase/main.swift
+++ b/Sources/PIRGenerateDatabase/main.swift
@@ -24,8 +24,6 @@ enum ValueTypeArguments: String, CaseIterable, ExpressibleByArgument {
     case repeated
 }
 
-// This executable is used in tests, which breaks `swift test -c release` when used with `@main`.
-// So we avoid using `@main` here.
 struct ValueSizeArguments: ExpressibleByArgument {
     let range: Range<Int>
 
@@ -59,6 +57,8 @@ extension [UInt8] {
     }
 }
 
+// This executable is used in tests, which breaks `swift test -c release` when used with `@main`.
+// So we avoid using `@main` here.
 struct GenerateDatabaseCommand: ParsableCommand {
     static let configuration: CommandConfiguration = .init(
         commandName: "PIRGenerateDatabase", version: Version.current.description)

--- a/Sources/PIRProcessDatabase/main.swift
+++ b/Sources/PIRProcessDatabase/main.swift
@@ -551,4 +551,9 @@ extension Duration {
     }
 }
 
-ProcessDatabase.main()
+// workaround to call the async main
+func main() async {
+    await ProcessDatabase.main()
+}
+
+await main()


### PR DESCRIPTION
We had a bug:
```
$ PIRProcessDatabase block-config.json
USAGE: PIRProcessDatabase <config-file> [--parallel] [--no-parallel]

ARGUMENTS:
  <config-file>           Path to json configuration file.
                          Default for PredefinedRlweParameters: n_4096_logq_27_28_28_logt_5:
                          {
                            "algorithm" : "mulPir",
                            "cuckooTableArguments" : {
                              "bucketCount" : {
                                "allowExpansion" : {
                                  "expansionFactor" : 1.1,
                                  "targetLoadFactor" : 0.9
                                }
                              },
                              "hashFunctionCount" : 2,
                              "maxEvictionCount" : 100,
                              "maxSerializedBucketSize" : 1024
                            },
                            "inputDatabase" : "/path/to/input/database.txtpb",
                            "keyCompression" : "noCompression",
                            "outputDatabase" : "/path/to/output/database-SHARD_ID.bin",
                            "outputEvaluationKeyConfig" : "/path/to/output/evaluation-key-config.txtpb",
                            "outputPirParameters" : "path/to/output/pir-parameters-SHARD_ID.txtpb",
                            "rlweParameters" : "n_4096_logq_27_28_28_logt_5",
                            "sharding" : {
                              "shardCount" : 1
                            },
                            "shardingFunction" : {
                              "sha256" : null
                            },
                            "trialsPerShard" : 1
                          }

OPTIONS:
  --parallel/--no-parallel
                          Enables parallel processing. (default: --parallel)
  --version               Show the version.
  -h, --help              Show help information.
```
Basically the command thinks that no arguments were passed to it.

The reasoning is interesting:
`ProcessDatabase` is an `AsyncParsableCommand`, but also a `ParsableCommand`.

When calling `ProcessDatabase.main()` it is ambiguous, if we are calling the:
`async main()` from `AsyncParsableCommand` or regular **sync** `main()` from `ParsableCommand`.

So we accidentally called the **sync** method.
The **sync** `main` can only call **sync** `run` method.
ProcessDatabase does not implement a **sync** `run` method, so the default implementation for `ParsableCommand` is used, which prints out the help message.