### PR TITLE
Faster context creation

### DIFF
--- a/Sources/HomomorphicEncryption/DoubleWidthUInt.swift
+++ b/Sources/HomomorphicEncryption/DoubleWidthUInt.swift
@@ -307,6 +307,7 @@ extension DoubleWidthUInt: FixedWidthInteger {
         return (result, didCarry)
     }
 
+    @inlinable
     public func quotientAndRemainder(
         dividingBy other: DoubleWidthUInt) -> (quotient: DoubleWidthUInt, remainder: DoubleWidthUInt)
     {
@@ -717,5 +718,5 @@ extension DoubleWidthUInt: UnsignedInteger where Base: FixedWidthInteger & Unsig
     }
 }
 
-@usableFromInline typealias QuadWidth<T: FixedWidthInteger & UnsignedInteger> = DoubleWidthUInt<DoubleWidthUInt<T>>
-@usableFromInline typealias OctoWidth<T: FixedWidthInteger & UnsignedInteger> = DoubleWidthUInt<QuadWidth<T>>
+@usableFromInline typealias QuadWidth<T: ModularArithmetic.CoreScalarType> = DoubleWidthUInt<T.DoubleWidth>
+@usableFromInline typealias OctoWidth<T: ModularArithmetic.CoreScalarType> = DoubleWidthUInt<QuadWidth<T>>

--- a/Sources/ModularArithmetic/Scalar.swift
+++ b/Sources/ModularArithmetic/Scalar.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,8 @@ public protocol CoreScalarType: FixedWidthInteger, UnsignedInteger, Sendable
     where Self.Magnitude: Sendable
 {
     /// Scalar which can hold a product of two `ScalarType` multiplicands.
-    associatedtype DoubleWidth: DoubleWidthType, Sendable where DoubleWidth.Scalar == Self
+    associatedtype DoubleWidth: DoubleWidthType, Sendable where DoubleWidth.Scalar == Self,
+        DoubleWidth.Magnitude: Sendable
 
     /// Holds signed values of the same bit-width.
     associatedtype SignedScalar: CoreSignedScalarType where SignedScalar.UnsignedScalar == Self


### PR DESCRIPTION
We add a context creation benchmark, and make a few optimizations.
* `QuadWidth<UInt64>` was `4 x UInt64`. Now it's `2 x UInt128`
* a missing `@inlinable`