### PR TITLE
Allow up to 32 coefficient moduli

### DIFF
--- a/Sources/HomomorphicEncryption/Bfv/Bfv+Decrypt.swift
+++ b/Sources/HomomorphicEncryption/Bfv/Bfv+Decrypt.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -83,12 +83,18 @@ extension Bfv {
         case tMax..<pow(tMax, 2):
             precondition(variableTime)
             return try computeNoiseBudget(of: vTimesT, T.DoubleWidth.self)
-        case tMax..<pow(tMax, 4):
+        case pow(tMax, 2)..<pow(tMax, 4):
             precondition(variableTime)
             return try computeNoiseBudget(of: vTimesT, QuadWidth<T>.self)
-        case tMax..<pow(tMax, 8):
+        case pow(tMax, 4)..<pow(tMax, 8):
             precondition(variableTime)
             return try computeNoiseBudget(of: vTimesT, OctoWidth<T>.self)
+        case pow(tMax, 8)..<pow(tMax, 16):
+            precondition(variableTime)
+            return try computeNoiseBudget(of: vTimesT, Width16<T>.self)
+        case pow(tMax, 16)..<pow(tMax, 32):
+            precondition(variableTime)
+            return try computeNoiseBudget(of: vTimesT, Width32<T>.self)
         default:
             preconditionFailure("crtMaxIntermediateValue \(crtMaxIntermediateValue) too large")
         }

--- a/Sources/HomomorphicEncryption/CrtComposer.swift
+++ b/Sources/HomomorphicEncryption/CrtComposer.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,9 +71,7 @@ package struct CrtComposer<T: ScalarType>: Sendable {
     /// - Warning: `V`'s operations must be constant time to prevent leaking
     /// `poly` through timing.
     @inlinable
-    package func compose<V: FixedWidthInteger &
-        UnsignedInteger>(data: Array2d<T>) throws -> [V]
-    {
+    package func compose<V: FixedWidthInteger & UnsignedInteger>(data: Array2d<T>) throws -> [V] {
         precondition(data.rowCount == polyContext.moduli.count)
         precondition(Double(V.max) >= Self
             .composeMaxIntermediateValue(moduli: polyContext.moduli))
@@ -109,10 +107,7 @@ package struct CrtComposer<T: ScalarType>: Sendable {
     /// - Warning: `V`'s operations must be constant time to prevent leaking
     /// `poly` through timing.
     @inlinable
-    package func compose<V: FixedWidthInteger & UnsignedInteger>(poly: PolyRq<
-        T,
-        Coeff
-    >) throws -> [V] {
+    package func compose<V: FixedWidthInteger & UnsignedInteger>(poly: PolyRq<T, Coeff>) throws -> [V] {
         try compose(data: poly.data)
     }
 }

--- a/Sources/HomomorphicEncryption/DoubleWidthUInt.swift
+++ b/Sources/HomomorphicEncryption/DoubleWidthUInt.swift
@@ -720,3 +720,5 @@ extension DoubleWidthUInt: UnsignedInteger where Base: FixedWidthInteger & Unsig
 
 @usableFromInline typealias QuadWidth<T: ModularArithmetic.CoreScalarType> = DoubleWidthUInt<T.DoubleWidth>
 @usableFromInline typealias OctoWidth<T: ModularArithmetic.CoreScalarType> = DoubleWidthUInt<QuadWidth<T>>
+@usableFromInline typealias Width16<T: ModularArithmetic.CoreScalarType> = DoubleWidthUInt<OctoWidth<T>>
+@usableFromInline typealias Width32<T: ModularArithmetic.CoreScalarType> = DoubleWidthUInt<Width16<T>>

--- a/Sources/HomomorphicEncryption/EncryptionParameters.swift
+++ b/Sources/HomomorphicEncryption/EncryptionParameters.swift
@@ -137,8 +137,8 @@ public struct EncryptionParameters<Scheme: HeScheme>: Hashable, Codable, Sendabl
         else {
             throw HeError.insecureEncryptionParameters(self)
         }
-        // Due to some usage of OctoWidth
-        guard coefficientModuli.count <= 8 else {
+        // Due to some usage of `Width32`
+        guard coefficientModuli.count <= 32 else {
             throw HeError.invalidEncryptionParameters(self)
         }
         for coefficientModulus in coefficientModuli {

--- a/Sources/HomomorphicEncryption/RnsTool.swift
+++ b/Sources/HomomorphicEncryption/RnsTool.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -110,15 +110,13 @@ package struct RnsTool<T: ScalarType>: Sendable {
         self.qModT = inputContext.qRemainder(dividingBy: t)
         self.tIncrement = inputContext.moduli.map { qi in qi - t.modulus }
         self.t = t
+        let composedQ = inputContext.modulus
+        let composedT = outputContext.modulus
+        let qDivTComposed = composedQ / composedT
 
-        // At least 8 moduli supported, more when their product is far from `T.max`.
-        let octoModuli = inputContext.moduli.map { modulus in OctoWidth<T>(integerLiteral: Int(modulus)) }
-        let q: OctoWidth<T> = inputContext.moduli.product()
-        let qDivT = q / OctoWidth<T>(integerLiteral: Int(t.modulus))
-
-        self.qDivT = octoModuli.map { qi in MultiplyConstantModulus(
-            multiplicand: T(qDivT % qi),
-            modulus: T(qi),
+        self.qDivT = inputContext.moduli.map { qi in MultiplyConstantModulus(
+            multiplicand: T(qDivTComposed % Width32<T>(qi)),
+            modulus: qi,
             variableTime: true)
         }
 

--- a/Sources/HomomorphicEncryption/Util.swift
+++ b/Sources/HomomorphicEncryption/Util.swift
@@ -87,3 +87,38 @@ extension Array where Element: FixedWidthInteger {
         reduce(V(0)) { V($0) + V($1) }
     }
 }
+
+extension Array where Element: ScalarType {
+    @inlinable
+    func product() -> Width32<Self.Element> {
+        func wideningProduct<Prod: FixedWidthInteger>(of elements: [some FixedWidthInteger]) -> [Prod] {
+            stride(from: 0, to: elements.count, by: 2).map { index in
+                var product = Prod(elements[index])
+                if index < elements.count - 1 {
+                    product &*= Prod(elements[index + 1])
+                }
+                return product
+            }
+        }
+
+        let doubleWidth: [Self.Element.DoubleWidth] = wideningProduct(of: self)
+        if doubleWidth.count == 1 {
+            return Width32<Self.Element>(doubleWidth[0])
+        }
+        let quadWidth: [QuadWidth<Self.Element>] = wideningProduct(of: doubleWidth)
+        if quadWidth.count == 1 {
+            return Width32<Self.Element>(quadWidth[0])
+        }
+        let octoWidth: [OctoWidth<Self.Element>] = wideningProduct(of: quadWidth)
+        if octoWidth.count == 1 {
+            return Width32<Self.Element>(octoWidth[0])
+        }
+        let width16: [Width16<Self.Element>] = wideningProduct(of: octoWidth)
+        if width16.count == 1 {
+            return Width32<Self.Element>(width16[0])
+        }
+        let width32: [Width32<Self.Element>] = wideningProduct(of: width16)
+        precondition(width32.count == 1)
+        return width32[0]
+    }
+}

--- a/Tests/HomomorphicEncryptionTests/HeAPITests.swift
+++ b/Tests/HomomorphicEncryptionTests/HeAPITests.swift
@@ -142,16 +142,27 @@ struct HeAPITests {
             }
         let custom = try EncryptionParameters<Bfv<T>>(
             polyDegree: TestUtils.testPolyDegree,
-            plaintextModulus: T
-                .generatePrimes(
-                    significantBitCounts: [12],
-                    preferringSmall: true,
-                    nttDegree: TestUtils.testPolyDegree)[0],
+            plaintextModulus: T.generatePrimes(
+                significantBitCounts: [12],
+                preferringSmall: true,
+                nttDegree: TestUtils.testPolyDegree)[0],
             coefficientModuli: HeAPITestHelpers.testCoefficientModuli(),
             errorStdDev: ErrorStdDev.stdDev32,
             securityLevel: SecurityLevel.unchecked)
+        let manyModuli = try EncryptionParameters<Bfv<T>>(
+            polyDegree: TestUtils.testPolyDegree,
+            plaintextModulus: T.generatePrimes(
+                significantBitCounts: [12],
+                preferringSmall: true,
+                nttDegree: TestUtils.testPolyDegree)[0],
+            coefficientModuli: T.generatePrimes(
+                significantBitCounts: Array(repeating: T.bitWidth - 4, count: 32),
+                preferringSmall: false,
+                nttDegree: TestUtils.testPolyDegree),
+            errorStdDev: ErrorStdDev.stdDev32,
+            securityLevel: SecurityLevel.unchecked)
 
-        for encryptionParameters in predefined + [custom] {
+        for encryptionParameters in predefined + [custom, manyModuli] {
             let context = try Context<Bfv<T>>(encryptionParameters: encryptionParameters)
             try HeAPITestHelpers.schemeEncodeDecodeTest(context: context)
             try HeAPITestHelpers.schemeEncryptDecryptTest(context: context)

--- a/Tests/HomomorphicEncryptionTests/PolyRqTests/PolyContextTests.swift
+++ b/Tests/HomomorphicEncryptionTests/PolyRqTests/PolyContextTests.swift
@@ -53,6 +53,7 @@ struct PolyContextTests {
         let context1 = try PolyContext<UInt32>(degree: 4, moduli: [2])
 
         #expect(context3.moduli == [2, 3, 5])
+        #expect(context3.modulus == Width32<UInt32>(30))
         #expect(context3.degree == 4)
         #expect(context3.next == context2)
         if let context3Next = context3.next {

--- a/Tests/HomomorphicEncryptionTests/UtilTests.swift
+++ b/Tests/HomomorphicEncryptionTests/UtilTests.swift
@@ -56,6 +56,8 @@ struct UtilTests {
         #expect([7].product() == 7)
         #expect([1, 2, 3].product() == 6)
         #expect([UInt8(255), UInt8(2)].product() == UInt16(510))
+
+        #expect([UInt32(1 << 17), UInt32(1 << 17)].product() == Width32<UInt32>(1 << 34))
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/apple/swift-homomorphic-encryption/issues/195
The restriction up to 8 moduli was arbitrary, so we expand it to 32 moduli.
A big runtime bottleneck was computing the modulus product in RnsTool initialization.
Given encryption parameters with L coefficient moduli, we create L RNS tools, one for each prefix of coeff moduli.
So for large `L`, this became a bottleneck, in particular the product computation `q = q_1 * ... * q_L`.

We avoid this by pre-computing `q: Width32<T>` for each context. This is some extra overhead, since not every `PolyContext` needs the full product, and `Width32` is wider than needed in most cases. But the slowdown isn't so bad. The slowdown became more extreme when I tried using `Width<64>`. So, for now, we limit to 32 moduli, rather than 64.

A proper fix would refactor the `RnsTool` to not create several `PolyContext` chains every time.