### PR TITLE
Faster context creation

### DIFF
--- a/Sources/HomomorphicEncryption/Context.swift
+++ b/Sources/HomomorphicEncryption/Context.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -103,10 +103,13 @@ public final class Context<Scheme: HeScheme>: Equatable, Sendable {
             degree: encryptionParameters.polyDegree,
             moduli: [encryptionParameters.plaintextModulus])
 
+        let rnsToolContext = try RnsTool.RnsToolContext(
+            inputContext: ciphertextContext,
+            outputContext: plaintextContext)
         var rnsToolsCiphertextContext = ciphertextContext
-        try rnsTools.append(RnsTool(from: ciphertextContext, to: plaintextContext))
+        try rnsTools.append(RnsTool(from: ciphertextContext, to: plaintextContext, rnsToolContext: rnsToolContext))
         while let nextContext = rnsToolsCiphertextContext.next {
-            try rnsTools.append(RnsTool(from: nextContext, to: plaintextContext))
+            try rnsTools.append(RnsTool(from: nextContext, to: plaintextContext, rnsToolContext: rnsToolContext))
             rnsToolsCiphertextContext = nextContext
         }
         self.rnsTools = rnsTools

--- a/Sources/HomomorphicEncryption/PolyRq/PolyRq+Ntt.swift
+++ b/Sources/HomomorphicEncryption/PolyRq/PolyRq+Ntt.swift
@@ -109,9 +109,12 @@ extension ScalarType {
 struct NttContext<T: ScalarType>: Sendable {
     @usableFromInline let rootOfUnityPowers: MultiplyConstantArrayModulus<T>
     @usableFromInline let inverseRootOfUnityPowers: MultiplyConstantArrayModulus<T>
-    @usableFromInline let inverseDegree: MultiplyConstantModulus<T> // degree^{-1} mod modulus
-    // (degree)^{-1} * w^{-N} mod modulus for `w` a root of unity mod modulus
+    /// `degree^{-1} mod modulus`.
+    @usableFromInline let inverseDegree: MultiplyConstantModulus<T>
+    /// `(degree)^{-1} * w^{-N} mod modulus` for `w` a root of unity mod modulus.
     @usableFromInline let inverseDegreeRootOfUnity: MultiplyConstantModulus<T>
+    @usableFromInline let degree: Int
+    @usableFromInline let modulus: T
 
     @inlinable
     init(degree: Int, modulus: T) throws {
@@ -134,6 +137,9 @@ struct NttContext<T: ScalarType>: Sendable {
                 inverseRootOfUnityPowers[previousIdx])
             previousIdx = reverseIdx
         }
+
+        self.degree = degree
+        self.modulus = modulus
         self.rootOfUnityPowers = MultiplyConstantArrayModulus(
             multiplicands: rootOfUnityPowers,
             modulus: modulus,

--- a/Sources/HomomorphicEncryption/RnsTool.swift
+++ b/Sources/HomomorphicEncryption/RnsTool.swift
@@ -16,6 +16,60 @@ import ModularArithmetic
 
 @usableFromInline
 package struct RnsTool<T: ScalarType>: Sendable {
+    @usableFromInline
+    struct RnsToolContext {
+        @usableFromInline let inputContext: PolyContext<T>
+        @usableFromInline let bSkMTildeContext: PolyContext<T>
+        @usableFromInline let mSkContext: PolyContext<T>
+        @usableFromInline let nttContexts: [T: NttContext<T>]
+        @usableFromInline let tGammaContext: PolyContext<T>
+
+        @inlinable
+        init(inputContext: PolyContext<T>, outputContext: PolyContext<T>) throws {
+            let degree = inputContext.degree
+            let bSkModuli = try T.generatePrimes(
+                significantBitCounts: Array(repeating: T.bitWidth - 3, count: inputContext.moduli.count + 1),
+                preferringSmall: true,
+                nttDegree: degree)
+            self.inputContext = inputContext
+
+            let bSkMTildeModuli = bSkModuli + [T.mTilde]
+            self.bSkMTildeContext = try PolyContext(degree: degree, moduli: bSkMTildeModuli)
+            guard let bSkModuli = bSkMTildeContext.next?.moduli else {
+                throw HeError.invalidPolyContext(bSkMTildeContext)
+            }
+            guard let mSk = bSkModuli.last else {
+                throw HeError.emptyModulus
+            }
+
+            var nttContexts = [T: NttContext<T>]()
+            for moduliCount in 1..<bSkMTildeContext.moduli.count {
+                if let nttContext = try bSkMTildeContext.getContext(moduliCount: moduliCount).nttContext {
+                    nttContexts[nttContext.modulus] = nttContext
+                }
+            }
+            for moduliCount in 1..<inputContext.moduli.count {
+                if let nttContext = try inputContext.getContext(moduliCount: moduliCount).nttContext {
+                    nttContexts[nttContext.modulus] = nttContext
+                }
+            }
+            self.nttContexts = nttContexts
+
+            self.mSkContext = try PolyContext(
+                degree: degree,
+                moduli: [mSk],
+                next: nil,
+                nttContext: nttContexts[mSk])
+            self.tGammaContext = try PolyContext(
+                degree: degree,
+                moduli: [outputContext.moduli[0], T.rnsCorrectionFactor], child: outputContext)
+        }
+
+        func getbSkMTildeNttContext(moduliCount: Int) throws -> NttContext<T>? {
+            try bSkMTildeContext.getContext(moduliCount: moduliCount).nttContext
+        }
+    }
+
     /// `Q = q_0, ..., q_{L-1}`.
     @usableFromInline let inputContext: PolyContext<T>
     /// `t_0, ..., t_{M-1}`.
@@ -75,7 +129,10 @@ package struct RnsTool<T: ScalarType>: Sendable {
     }
 
     @inlinable
-    init(from inputContext: PolyContext<T>, to outputContext: PolyContext<T>) throws {
+    init(from inputContext: PolyContext<T>,
+         to outputContext: PolyContext<T>,
+         rnsToolContext: RnsToolContext) throws
+    {
         guard inputContext.degree == outputContext.degree, outputContext.moduli.count == 1 else {
             throw HeError.invalidPolyContext(inputContext)
         }
@@ -92,7 +149,7 @@ package struct RnsTool<T: ScalarType>: Sendable {
             modulus: t.modulus,
             variableTime: true)
 
-        let tGammaContext = try PolyContext(degree: degree, moduli: [t.modulus, correctionFactor])
+        let tGammaContext = rnsToolContext.tGammaContext
         self.rnsConvertQToTGamma = try RnsBaseConverter(from: inputContext, to: tGammaContext)
         self.negInverseQModTGamma = try tGammaContext.reduceModuli.map { modulus in
             let qMod = inputContext.qRemainder(dividingBy: modulus)
@@ -121,21 +178,19 @@ package struct RnsTool<T: ScalarType>: Sendable {
         }
 
         // auxiliary base B_sk = [B, m_sk]
-        let bSkModuli = try T.generatePrimes(
-            significantBitCounts: Array(repeating: T.bitWidth - 3, count: inputContext.moduli.count + 1),
-            preferringSmall: true,
-            nttDegree: degree)
-        let bSkMTildeModuli = bSkModuli + [T.mTilde]
-        guard let mSk = bSkModuli.last else {
-            throw HeError.emptyModulus
-        }
-
-        let bSkMTildeContext = try PolyContext(degree: degree, moduli: bSkMTildeModuli)
+        let bSkMTildeContext = try rnsToolContext.bSkMTildeContext
+            .getContext(moduliCount: inputContext.moduli.count + 2)
         guard let bSkContext = bSkMTildeContext.next else {
             throw HeError.invalidPolyContext(bSkMTildeContext)
         }
         guard let bContext = bSkContext.next else {
             throw HeError.invalidPolyContext(bSkContext)
+        }
+        guard let bSkModuli = bSkMTildeContext.next?.moduli else {
+            throw HeError.invalidPolyContext(bSkMTildeContext)
+        }
+        guard let mSk = bSkModuli.last else {
+            throw HeError.emptyModulus
         }
 
         let bModQi = inputContext.reduceModuli.map { qi in
@@ -167,7 +222,11 @@ package struct RnsTool<T: ScalarType>: Sendable {
         self.mTildeModQ = inputContext.reduceModuli.map { qi in qi.reduce(T.mTilde) }
 
         let qBSkModuli = inputContext.moduli + bSkModuli
-        self.qBskContext = try PolyContext(degree: degree, moduli: qBSkModuli)
+        self.qBskContext = try PolyContext(
+            degree: degree,
+            moduli: qBSkModuli,
+            child: inputContext,
+            nttContexts: rnsToolContext.nttContexts)
 
         self.inverseQModBSk = try bSkContext.reduceModuli.map { modulus in
             let qMod = inputContext.qRemainder(dividingBy: modulus)
@@ -175,7 +234,7 @@ package struct RnsTool<T: ScalarType>: Sendable {
             return MultiplyConstantModulus(multiplicand: multiplicand, divisionModulus: modulus.divisionModulus)
         }
 
-        let mSkContext = try PolyContext(degree: degree, moduli: [mSk])
+        let mSkContext = rnsToolContext.mSkContext
         self.inverseBModMSk = try {
             let bModMSk = bContext.qRemainder(dividingBy: mSkContext.reduceModuli[0])
             let multiplicand = try bModMSk.inverseMod(modulus: mSk, variableTime: true)
@@ -185,6 +244,14 @@ package struct RnsTool<T: ScalarType>: Sendable {
         self.rnsConvertQToBSkMTilde = try RnsBaseConverter(from: inputContext, to: bSkMTildeContext)
         self.rnsConvertBtoMSk = try RnsBaseConverter(from: bContext, to: mSkContext)
         self.rnsConvertBtoQ = try RnsBaseConverter(from: bContext, to: inputContext)
+    }
+
+    @inlinable
+    init(from inputContext: PolyContext<T>,
+         to outputContext: PolyContext<T>) throws
+    {
+        let rnsToolContext = try RnsTool.RnsToolContext(inputContext: inputContext, outputContext: outputContext)
+        try self.init(from: inputContext, to: outputContext, rnsToolContext: rnsToolContext)
     }
 
     /// Performs scaling and rounding.

--- a/Sources/HomomorphicEncryption/RnsTool.swift
+++ b/Sources/HomomorphicEncryption/RnsTool.swift
@@ -167,8 +167,12 @@ package struct RnsTool<T: ScalarType>: Sendable {
         self.qModT = inputContext.qRemainder(dividingBy: t)
         self.tIncrement = inputContext.moduli.map { qi in qi - t.modulus }
         self.t = t
-        let composedQ = inputContext.modulus
-        let composedT = outputContext.modulus
+        guard let composedQ = inputContext.modulus else {
+            throw HeError.invalidPolyContext(inputContext)
+        }
+        guard let composedT = outputContext.modulus else {
+            throw HeError.invalidPolyContext(outputContext)
+        }
         let qDivTComposed = composedQ / composedT
 
         self.qDivT = inputContext.moduli.map { qi in MultiplyConstantModulus(

--- a/Sources/HomomorphicEncryption/Util.swift
+++ b/Sources/HomomorphicEncryption/Util.swift
@@ -101,6 +101,9 @@ extension Array where Element: ScalarType {
             }
         }
 
+        if count == 1 {
+            return Width32<Self.Element>(self[0])
+        }
         let doubleWidth: [Self.Element.DoubleWidth] = wideningProduct(of: self)
         if doubleWidth.count == 1 {
             return Width32<Self.Element>(doubleWidth[0])

--- a/Sources/HomomorphicEncryption/Util.swift
+++ b/Sources/HomomorphicEncryption/Util.swift
@@ -121,7 +121,7 @@ extension Array where Element: ScalarType {
             return Width32<Self.Element>(width16[0])
         }
         let width32: [Width32<Self.Element>] = wideningProduct(of: width16)
-        precondition(width32.count == 1)
-        return width32[0]
+
+        return width32.reduce(Width32<Self.Element>(1)) { $0 * $1 }
     }
 }

--- a/Tests/HomomorphicEncryptionTests/PolyRqTests/PolyContextTests.swift
+++ b/Tests/HomomorphicEncryptionTests/PolyRqTests/PolyContextTests.swift
@@ -83,6 +83,28 @@ struct PolyContextTests {
     }
 
     @Test
+    func initLarge() throws {
+        let moduli = try UInt32.generatePrimes(
+            significantBitCounts: Array(repeating: 28, count: 40),
+            preferringSmall: false)
+        var context = try PolyContext<UInt32>(degree: 4, moduli: moduli)
+        for moduliCount in (2...moduli.count).reversed() {
+            #expect(context.moduli == Array(moduli.prefix(moduliCount)))
+            #expect(context.degree == 4)
+            if moduliCount * 28 < Width32<UInt32>.bitWidth {
+                #expect(context.modulus == context.moduli.product())
+            } else {
+                #expect(context.modulus == nil)
+            }
+            if let next = context.next {
+                context = next
+            } else {
+                Issue.record("Missing next")
+            }
+        }
+    }
+
+    @Test
     func qRemainder() throws {
         let contextSmall: PolyContext<UInt32> = try PolyContext(degree: 4, moduli: [2, 3, 5])
         #expect(contextSmall.qRemainder(dividingBy: Modulus(modulus: 11, variableTime: true)) == 8)

--- a/Tests/HomomorphicEncryptionTests/PolyRqTests/PolyContextTests.swift
+++ b/Tests/HomomorphicEncryptionTests/PolyRqTests/PolyContextTests.swift
@@ -65,6 +65,24 @@ struct PolyContextTests {
     }
 
     @Test
+    func testInitChild() throws {
+        let context1 = try PolyContext<UInt32>(degree: 4, moduli: [2])
+        let context2 = try PolyContext<UInt32>(degree: 4, moduli: [2, 3])
+        let context3 = try PolyContext<UInt32>(degree: 4, moduli: [2, 3, 5], child: context1)
+
+        #expect(context3.moduli == [2, 3, 5])
+        #expect(context3.modulus == Width32<UInt32>(30))
+        #expect(context3.degree == 4)
+        #expect(context3.next == context2)
+        if let context3Next = context3.next {
+            #expect(context3Next.next == context1)
+            if let context3NextNext = context3Next.next {
+                #expect(context3NextNext.next == nil)
+            }
+        }
+    }
+
+    @Test
     func qRemainder() throws {
         let contextSmall: PolyContext<UInt32> = try PolyContext(degree: 4, moduli: [2, 3, 5])
         #expect(contextSmall.qRemainder(dividingBy: Modulus(modulus: 11, variableTime: true)) == 8)

--- a/Tests/HomomorphicEncryptionTests/RnsToolTests.swift
+++ b/Tests/HomomorphicEncryptionTests/RnsToolTests.swift
@@ -210,11 +210,7 @@ struct RnsToolTests {
 
     @Test
     func approximateFloor() throws {
-        func runTestApproximateFloor<T: ScalarType>(
-            _: T.Type,
-            degree: Int,
-            significantBitCounts: [Int]) throws
-        {
+        func runTestApproximateFloor<T: ScalarType>(_: T.Type, degree: Int, significantBitCounts: [Int]) throws {
             let inputModuli = try T.generatePrimes(significantBitCounts: significantBitCounts, preferringSmall: true)
             let inputContext = try PolyContext(degree: degree, moduli: inputModuli)
             let outputContext = try PolyContext(degree: degree, moduli: [T(2)]) // arbitrary

--- a/Tests/HomomorphicEncryptionTests/UtilTests.swift
+++ b/Tests/HomomorphicEncryptionTests/UtilTests.swift
@@ -57,8 +57,12 @@ struct UtilTests {
         #expect([1, 2, 3].product() == 6)
         #expect([UInt8(255), UInt8(2)].product() == UInt16(510))
 
-        #expect([UInt32(1 << 17), UInt32(1 << 17)].product() == Width32<UInt32>(1 << 34))
-        #expect([UInt32(1 << 17)].product() == Width32<UInt32>(1 << 17))
+        var values = [UInt32]()
+        for count in 1...31 {
+            values.append(UInt32(1 << count))
+            let sumOfPowers = count * (count + 1) / 2
+            #expect(values.product() == Width32<UInt32>(1) << sumOfPowers)
+        }
     }
 
     @Test

--- a/Tests/HomomorphicEncryptionTests/UtilTests.swift
+++ b/Tests/HomomorphicEncryptionTests/UtilTests.swift
@@ -58,6 +58,7 @@ struct UtilTests {
         #expect([UInt8(255), UInt8(2)].product() == UInt16(510))
 
         #expect([UInt32(1 << 17), UInt32(1 << 17)].product() == Width32<UInt32>(1 << 34))
+        #expect([UInt32(1 << 17)].product() == Width32<UInt32>(1 << 17))
     }
 
     @Test


### PR DESCRIPTION
`PolyContext` initialization in `RnsTool` is a big bottleneck in `Context` creation, especially for contexts with many moduli. A lot of the runtime is in repeated computation: as we build a chain of `RnsTool`s, each `RnsTool` initializer re-computes the `PolyContexts` for the whole chain.

To avoid this, we create a `RnsToolContext`, which does some pre computation, both for the whole `PolyContext` context, and, when that doesn't apply, for the `NttContext`.

As a nice side effect, we also reduce the peak memory usage, which could have its own benefits.

We also avoid overflow in `PolyContext.modulus` for large contexts.

Before
```
ContextInit/Bfv<UInt32>/N=8192/logt=[18]/logq=[28, 28, 28, 28, 28]
╒═══════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                        │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞═══════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Malloc (total) *              │      1016 │      1016 │      1016 │      1016 │      1016 │      1016 │      1016 │       282 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Memory (resident peak) (M)    │        28 │        33 │        33 │        33 │        33 │        33 │        33 │       282 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (ms) *      │        10 │        10 │        10 │        10 │        11 │        12 │        15 │       282 │
╘═══════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

ContextInit/Bfv<UInt64>/N=8192/logt=[18]/logq=[33, 33, 33, 33, 33]
╒═══════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                        │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞═══════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Malloc (total) *              │      1024 │      1024 │      1024 │      1024 │      1024 │      1024 │      1024 │       164 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Memory (resident peak) (M)    │        32 │        41 │        42 │        42 │        42 │        42 │        42 │       164 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (ms) *      │        17 │        18 │        18 │        18 │        18 │        19 │        20 │       164 │
╘═══════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛
```

After
```
ContextInit/Bfv<UInt32>/N=8192/logt=[18]/logq=[28, 28, 28, 28, 28]
╒═══════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                        │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞═══════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Malloc (total) *              │       545 │       545 │       545 │       545 │       545 │       545 │       545 │       740 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Memory (resident peak) (M)    │        16 │        17 │        17 │        17 │        17 │        17 │        17 │       740 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (μs) *      │      3450 │      3746 │      3803 │      3850 │      3908 │      4139 │      4808 │       740 │
╘═══════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

ContextInit/Bfv<UInt64>/N=8192/logt=[18]/logq=[33, 33, 33, 33, 33]
╒═══════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                        │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞═══════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Malloc (total) *              │       551 │       551 │       551 │       551 │       551 │       551 │       551 │       373 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Memory (resident peak) (M)    │        19 │        21 │        21 │        21 │        21 │        21 │        21 │       373 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (μs) *      │      7176 │      7545 │      7623 │      7803 │      8032 │      8602 │      9113 │       373 │
╘═══════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛
```
