### PR TITLE
Remove benchmarks-related packages from Package.resolved

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,33 +1,6 @@
 {
-  "originHash" : "d78e7ebf7fa3bf42fbf02fe4a51bb42513afbb8c2a81f8ad9410653a96964c38",
+  "originHash" : "61d8aacb16c7a03dacafd8211476f27983fcc16b9cacad985296a457df03603c",
   "pins" : [
-    {
-      "identity" : "hdrhistogram-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/HdrHistogram/hdrhistogram-swift",
-      "state" : {
-        "revision" : "93a1618c8aa20f6a521a9da656a3e0591889e9dc",
-        "version" : "0.1.3"
-      }
-    },
-    {
-      "identity" : "package-benchmark",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/package-benchmark",
-      "state" : {
-        "revision" : "ec06262cf296aaa4bd40ed654ccdf9a87fe1879f",
-        "version" : "1.29.2"
-      }
-    },
-    {
-      "identity" : "package-jemalloc",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/package-jemalloc",
-      "state" : {
-        "revision" : "e8a5db026963f5bfeac842d9d3f2cc8cde323b49",
-        "version" : "1.0.0"
-      }
-    },
     {
       "identity" : "swift-algorithms",
       "kind" : "remoteSourceControl",
@@ -53,15 +26,6 @@
       "state" : {
         "revision" : "ae33e5941bb88d88538d0a6b19ca0b01e6c76dcf",
         "version" : "1.3.1"
-      }
-    },
-    {
-      "identity" : "swift-atomics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics",
-      "state" : {
-        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
-        "version" : "1.2.0"
       }
     },
     {
@@ -116,24 +80,6 @@
       "state" : {
         "revision" : "d72aed98f8253ec1aa9ea1141e28150f408cf17f",
         "version" : "1.29.0"
-      }
-    },
-    {
-      "identity" : "swift-system",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system",
-      "state" : {
-        "revision" : "a34201439c74b53f0fd71ef11741af7e7caf01e1",
-        "version" : "1.4.2"
-      }
-    },
-    {
-      "identity" : "texttable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/TextTable",
-      "state" : {
-        "revision" : "a27a07300cf4ae322e0079ca0a475c5583dd575f",
-        "version" : "0.0.2"
       }
     }
   ],


### PR DESCRIPTION
Benchmarking is an opt-in feature. So we remove those dependencies from `Package.resolved`