### PR TITLE
Remove swift 5.8 from linux_exclude_swift_versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
       enable_windows_checks: false
-      # TODO: remove 5.8 after https://github.com/swiftlang/github-workflows/pull/107
-      linux_exclude_swift_versions: "[{\"swift_version\": \"5.8\"}, {\"swift_version\": \"5.9\"}, {\"swift_version\": \"5.10\"}]"
+      linux_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}, {\"swift_version\": \"5.10\"}]"
       linux_pre_build_command: "apt-get update && apt-get install -y libjemalloc-dev"
       linux_build_command: >
         swift test --configuration release;


### PR DESCRIPTION
https://github.com/swiftlang/github-workflows/pull/107 dropped support for swift 5.8.
So we no longer need to exclude it.