### PR TITLE
PIRBenchmark report evaluation key / query / response counts

### DIFF
--- a/Sources/BenchmarkUtilities/PirBenchmarkUtilities.swift
+++ b/Sources/BenchmarkUtilities/PirBenchmarkUtilities.swift
@@ -380,8 +380,11 @@ public func keywordPirBenchmark<Scheme: HeScheme>(_: Scheme.Type, entryCount: In
                                                                       using: benchmarkContext.evaluationKey))
             }
             benchmark.measurement(.evaluationKeySize, benchmarkContext.evaluationKeySize)
+            benchmark.measurement(.evaluationKeyCount, benchmarkContext.evaluationKeyCount)
             benchmark.measurement(.querySize, benchmarkContext.querySize)
+            benchmark.measurement(.queryCiphertextCount, benchmarkContext.queryCiphertextCount)
             benchmark.measurement(.responseSize, benchmarkContext.responseSize)
+            benchmark.measurement(.responseCiphertextCount, benchmarkContext.responseCiphertextCount)
             benchmark.measurement(.noiseBudget, benchmarkContext.noiseBudget)
         } setup: {
             try await KeywordPirBenchmarkContext<MulPirServer<Scheme>, MulPirClient<Scheme>>(


### PR DESCRIPTION
https://github.com/apple/swift-homomorphic-encryption/pull/186 mistakenly removed `Evaluation key count`, `Query ciphertext count`, `Response ciphertext count` from KeywordPir benchmarks. So we add them again.

Now we have, e.g., 
```
KeywordPir/Bfv<UInt64>/N=4096/logt=5/logq=[27, 28, 28]/entryCount=10000/entrySize=100/keyCompression=noCompression
╒══════════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                           │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞══════════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Evaluation key byte size (K) *   │       681 │       681 │       681 │       681 │       681 │       681 │       681 │        92 │
├──────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Evaluation key count *           │         8 │         8 │         8 │         8 │         8 │         8 │         8 │        92 │
├──────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Malloc (total) *                 │      6609 │      6611 │      6611 │      6611 │      6611 │      6611 │      6611 │        92 │
├──────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Memory (resident peak) (M)       │       108 │       113 │       113 │       113 │       113 │       113 │       113 │        92 │
├──────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Noise budget x 10 *              │       110 │       110 │       110 │       110 │       110 │       110 │       110 │        92 │
├──────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Query byte size (K) *            │        28 │        28 │        28 │        28 │        28 │        28 │        28 │        92 │
├──────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Query ciphertext count *         │         1 │         1 │         1 │         1 │         1 │         1 │         1 │        92 │
├──────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Response byte size (K) *         │        25 │        25 │        25 │        25 │        25 │        25 │        25 │        92 │
├──────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Response ciphertext count *      │         2 │         2 │         2 │         2 │         2 │         2 │         2 │        92 │
├──────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (ms) *         │        53 │        54 │        54 │        55 │        56 │        58 │        58 │        92 │
╘══════════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛
```