### PR TITLE
Use swift:6.1-noble for documentation check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
     with:
       # https://github.com/swiftlang/swift-package-manager/issues/8103
       api_breakage_check_enabled: false
+      # swift:6.2-noble leads to issues with Snippets
+      # e.g. https://github.com/apple/swift-homomorphic-encryption/actions/runs/18144503507/job/51643132814#step:5:1087
+      docs_check_container_image: swift:6.1-noble
       format_check_enabled: false
   tests:
     name: swifttests


### PR DESCRIPTION
The soundness check updated container images to swift 6.2 (https://github.com/swiftlang/github-workflows/pull/164), causing recent CI failures.
As a workaround, we hard-code the docs check to use swift 6.1