### PR TITLE
Fix Sendable warning

### DIFF
--- a/Sources/HomomorphicEncryption/HeScheme.swift
+++ b/Sources/HomomorphicEncryption/HeScheme.swift
@@ -89,7 +89,7 @@ public struct SimdEncodingDimensions: Codable, Equatable, Hashable, Sendable {
 ///
 /// The protocol should be implemented when adding a new HE scheme.
 /// However, several functions have an alternative API which is more ergonomic and should be preferred.
-public protocol HeScheme {
+public protocol HeScheme: Sendable {
     /// Coefficient type for each polynomial.
     associatedtype Scalar: ScalarType
     /// Coefficient type for signed encoding/decoding.


### PR DESCRIPTION
Fixes a warning
```swift
437 |                 for (shardID, shard) in shards {
438 |                     group.addTask { @Sendable [self] in
439 |                         try await processShard(
|                                   `- warning: capture of non-Sendable type 'Scheme.Type' in an isolated closure [#SendableMetatypes]
440 |                             shardID: shardID,
441 |                             shard: shard,
```