### PR TITLE
Disable DocC plugin by default

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dbabab7072a43035502b47866f915f3b5063c184698a44bbb53c9e887acd9cfc",
+  "originHash" : "3b554910bbc76ac563097effe5ba38eb7a8f36f6260a82637bbbb208737f4735",
   "pins" : [
     {
       "identity" : "swift-algorithms",
@@ -35,24 +35,6 @@
       "state" : {
         "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
         "version" : "3.15.1"
-      }
-    },
-    {
-      "identity" : "swift-docc-plugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-docc-plugin",
-      "state" : {
-        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
-        "version" : "1.4.5"
-      }
-    },
-    {
-      "identity" : "swift-docc-symbolkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
-      "state" : {
-        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
-        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-numerics", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-protobuf", from: "1.31.1"), // Keep version in sync with README
-        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -297,6 +296,22 @@ if enableBenchmarking {
             plugins: [
                 .plugin(name: "BenchmarkPlugin", package: "package-benchmark"),
             ]),
+    ]
+}
+
+// MARK: - DoCC plugin
+
+var enableDocCPlugin: Bool {
+    let benchmarkFlags = "SWIFT_HOMOMORPHIC_ENCRYPTION_ENABLE_DOCCPLUGIN"
+    if let flag = ProcessInfo.processInfo.environment[benchmarkFlags], flag == "1" {
+        return true
+    }
+    return false
+}
+
+if enableDocCPlugin {
+    package.dependencies += [
+        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
     ]
 }
 

--- a/README.md
+++ b/README.md
@@ -246,9 +246,9 @@ The documentation can be built from Xcode via `Product -> Build Documentation`.
 ## Command line
 The documentation can be built from command line by running
 ```sh
-swift package generate-documentation
+SWIFT_HOMOMORPHIC_ENCRYPTION_ENABLE_DOCCPLUGIN=1 swift package generate-documentation
 ```
 and previewed by running
 ```sh
-swift package --disable-sandbox preview-documentation --target HomomorphicEncryption
+SWIFT_HOMOMORPHIC_ENCRYPTION_ENABLE_DOCCPLUGIN=1 swift package --disable-sandbox preview-documentation --target HomomorphicEncryption
 ```


### PR DESCRIPTION
Having a dependency on SwiftDocCPlugin and SymbolKit is unnecessary in most cases.