### PR TITLE
Replace unsafe iteration with use of Span

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 // Remember to update CI if changing
 
@@ -318,6 +318,6 @@ if enableDocCPlugin {
 // Set the minimum macOS version for the package
 #if canImport(Darwin)
 package.platforms = [
-    .macOS(.v15), // Constrained by UInt128 support
+    .macOS(.v26), // Constrained by UInt128 support
 ]
 #endif

--- a/Sources/HomomorphicEncryption/Bfv/Bfv+Encrypt.swift
+++ b/Sources/HomomorphicEncryption/Bfv/Bfv+Encrypt.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -85,61 +85,57 @@ extension Bfv {
 
         let plaintextIndices = plaintext.poly.polyIndices(rnsIndex: 0)
         var adjust = plaintext
-        // swiftlint:disable:next closure_body_length
-        plaintext.poly.data.data.withUnsafeBufferPointer { plaintextData in
-            adjust.poly.data.data.withUnsafeMutableBufferPointer { adjustPtr in
-                let t = rnsTool.t.modulus
-                if T.DoubleWidth(t.multipliedFullWidth(by: t)) <= T.max {
-                    // Prefer single-word division, since it's faster
-                    for index in plaintextIndices {
-                        var adjustCoeff = rnsTool.qModT &* plaintextData[index]
-                        adjustCoeff &+= rnsTool.tThreshold
-                        adjustPtr[index] = adjustCoeff.dividingFloor(by: rnsTool.t)
-                    }
-                } else {
-                    let tThreshold = Scalar.DoubleWidth(rnsTool.tThreshold)
-                    for index in plaintextIndices {
-                        var adjustCoeff = Scalar
-                            .DoubleWidth(rnsTool.qModT.multipliedFullWidth(by: plaintextData[index]))
-                        adjustCoeff &+= tThreshold
-                        adjustPtr[index] = adjustCoeff.dividingFloor(by: rnsTool.t).low
-                    }
-                }
-            }
 
-            var c0 = ciphertext.polys[0]
-            let c1 = ciphertext.polys[1] // used for polynomial index computation only
-
-            switch op {
-            case PlaintextTranslateOp.Add:
-                c0.data.data.withUnsafeMutableBufferPointer { c0Ptr in
-                    for (rnsIndex, rnsDelta) in rnsTool.qDivT.enumerated() {
-                        for (plainIndex, cipherIndex) in c1.polyIndices(rnsIndex: rnsIndex).enumerated() {
-                            let plainTimesDelta = rnsDelta.multiplyMod(plaintextData[plainIndex])
-                            let roundQTimesMt = plainTimesDelta.addMod(
-                                adjust[plainIndex],
-                                modulus: rnsDelta.modulus)
-                            c0Ptr[cipherIndex] = c0Ptr[cipherIndex].addMod(roundQTimesMt, modulus: rnsDelta.modulus)
-                        }
-                    }
-                }
-            case PlaintextTranslateOp.Subtract:
-                c0.data.data.withUnsafeMutableBufferPointer { c0Ptr in
-                    for (rnsIndex, rnsDelta) in rnsTool.qDivT.enumerated() {
-                        for (plainIndex, cipherIndex) in c1.polyIndices(rnsIndex: rnsIndex).enumerated() {
-                            let plainTimesDelta = rnsDelta.multiplyMod(plaintextData[plainIndex])
-                            let roundQTimesMt = plainTimesDelta.addMod(
-                                adjust[plainIndex],
-                                modulus: rnsDelta.modulus)
-                            c0Ptr[cipherIndex] = c0Ptr[cipherIndex].subtractMod(
-                                roundQTimesMt,
-                                modulus: rnsDelta.modulus)
-                        }
-                    }
-                }
+        let plaintextData = plaintext.poly.data.data.span
+        var adjustSpan = adjust.poly.data.data.mutableSpan
+        let t = rnsTool.t.modulus
+        if T.DoubleWidth(t.multipliedFullWidth(by: t)) <= T.max {
+            // Prefer single-word division, since it's faster
+            for index in plaintextIndices {
+                var adjustCoeff = rnsTool.qModT &* plaintextData[index]
+                adjustCoeff &+= rnsTool.tThreshold
+                adjustSpan[index] = adjustCoeff.dividingFloor(by: rnsTool.t)
             }
-            ciphertext.polys[0] = c0
+        } else {
+            let tThreshold = Scalar.DoubleWidth(rnsTool.tThreshold)
+            for index in plaintextIndices {
+                var adjustCoeff = Scalar
+                    .DoubleWidth(rnsTool.qModT.multipliedFullWidth(by: plaintextData[index]))
+                adjustCoeff &+= tThreshold
+                adjustSpan[index] = adjustCoeff.dividingFloor(by: rnsTool.t).low
+            }
         }
+
+        var c0 = ciphertext.polys[0]
+        let c1 = ciphertext.polys[1] // used for polynomial index computation only
+
+        switch op {
+        case PlaintextTranslateOp.Add:
+            var c0Span = c0.data.data.mutableSpan
+            for (rnsIndex, rnsDelta) in rnsTool.qDivT.enumerated() {
+                for (plainIndex, cipherIndex) in c1.polyIndices(rnsIndex: rnsIndex).enumerated() {
+                    let plainTimesDelta = rnsDelta.multiplyMod(plaintextData[plainIndex])
+                    let roundQTimesMt = plainTimesDelta.addMod(
+                        adjust[plainIndex],
+                        modulus: rnsDelta.modulus)
+                    c0Span[cipherIndex] = c0Span[cipherIndex].addMod(roundQTimesMt, modulus: rnsDelta.modulus)
+                }
+            }
+        case PlaintextTranslateOp.Subtract:
+            var c0Span = c0.data.data.mutableSpan
+            for (rnsIndex, rnsDelta) in rnsTool.qDivT.enumerated() {
+                for (plainIndex, cipherIndex) in c1.polyIndices(rnsIndex: rnsIndex).enumerated() {
+                    let plainTimesDelta = rnsDelta.multiplyMod(plaintextData[plainIndex])
+                    let roundQTimesMt = plainTimesDelta.addMod(
+                        adjust[plainIndex],
+                        modulus: rnsDelta.modulus)
+                    c0Span[cipherIndex] = c0Span[cipherIndex].subtractMod(
+                        roundQTimesMt,
+                        modulus: rnsDelta.modulus)
+                }
+            }
+        }
+        ciphertext.polys[0] = c0
     }
 
     @inlinable

--- a/Sources/HomomorphicEncryption/Bfv/Bfv+Keys.swift
+++ b/Sources/HomomorphicEncryption/Bfv/Bfv+Keys.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -178,25 +178,23 @@ extension Bfv {
                 for (index, poly) in keyCiphers[decomposeIndex].polys.enumerated() {
                     let accIndex = poly.data.index(row: index, column: 0)
                     let polyIndex = poly.data.index(row: keyIndex, column: 0)
-                    poly.data.data.withUnsafeBufferPointer { polyPtr in
-                        for columnIndex in 0..<degree {
-                            let prod = bufferSlice[columnIndex]
-                                .multipliedFullWidth(by: polyPtr[polyIndex &+ columnIndex])
-                            // Overflow avoided by `maxLazyProductAccumulationCount()` check during context
-                            // initialization
-                            accumulator[accIndex &+ columnIndex] &+= T.DoubleWidth(prod)
-                        }
+                    let polySpan = poly.data.data.span
+                    for columnIndex in 0..<degree {
+                        let prod = bufferSlice[columnIndex]
+                            .multipliedFullWidth(by: polySpan[polyIndex &+ columnIndex])
+                        // Overflow avoided by `maxLazyProductAccumulationCount()` check during context
+                        // initialization
+                        accumulator[accIndex &+ columnIndex] &+= T.DoubleWidth(prod)
                     }
                 }
             }
             let prodIndex = ciphertextProd.polys[0].data.index(row: rnsIndex, column: 0)
             for rowIndex in ciphertextProd.polys.indices {
                 let accIndex = accumulator.index(row: rowIndex, column: 0)
-                ciphertextProd.polys[rowIndex].data.data.withUnsafeMutableBufferPointer { ciphertextProdPtr in
-                    for columnIndex in 0..<degree {
-                        ciphertextProdPtr[prodIndex &+ columnIndex] = keyModulus
-                            .reduce(accumulator[accIndex &+ columnIndex])
-                    }
+                var ciphertextProdSpan = ciphertextProd.polys[rowIndex].data.data.mutableSpan
+                for columnIndex in 0..<degree {
+                    ciphertextProdSpan[prodIndex &+ columnIndex] = keyModulus
+                        .reduce(accumulator[accIndex &+ columnIndex])
                 }
             }
         }

--- a/Sources/HomomorphicEncryption/Bfv/Bfv.swift
+++ b/Sources/HomomorphicEncryption/Bfv/Bfv.swift
@@ -283,13 +283,11 @@ public enum Bfv<T: ScalarType>: HeScheme {
     {
         let poly = result.polys[0]
         for (polyIndex, accumulatorPoly) in accumulator.enumerated() {
-            accumulatorPoly.data.withUnsafeBufferPointer { accumulatorPolyPtr in
-                result.polys[polyIndex].data.data.withUnsafeMutableBufferPointer { resultPtr in
-                    for (rnsIndex, modulus) in poly.polyContext().reduceModuli.enumerated() {
-                        for index in poly.polyIndices(rnsIndex: rnsIndex) {
-                            resultPtr[index] = modulus.reduce(accumulatorPolyPtr[index])
-                        }
-                    }
+            let accumulatorPolySpan = accumulatorPoly.data.span
+            var resultSpan = result.polys[polyIndex].data.data.mutableSpan
+            for (rnsIndex, modulus) in poly.polyContext().reduceModuli.enumerated() {
+                for index in poly.polyIndices(rnsIndex: rnsIndex) {
+                    resultSpan[index] = modulus.reduce(accumulatorPolySpan[index])
                 }
             }
         }

--- a/Sources/HomomorphicEncryption/PolyRq/Galois.swift
+++ b/Sources/HomomorphicEncryption/PolyRq/Galois.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -121,19 +121,17 @@ extension PolyRq where F == Coeff {
             func outputIndex(column: Int) -> Int {
                 data.index(row: rnsIndex, column: column)
             }
-            data.data.withUnsafeBufferPointer { dataPtr in
-                output.data.data.withUnsafeMutableBufferPointer { outputPtr in
-                    for dataIndex in dataIndices {
-                        guard let (negate, outIndex) = iterator.next() else {
-                            preconditionFailure("GaloisCoeffIterator goes out of index")
-                        }
-                        if negate {
-                            outputPtr[outputIndex(column: outIndex)] = dataPtr[dataIndex]
-                                .negateMod(modulus: modulus)
-                        } else {
-                            outputPtr[outputIndex(column: outIndex)] = dataPtr[dataIndex]
-                        }
-                    }
+            let dataSpan = data.data.span
+            var outputSpan = output.data.data.mutableSpan
+            for dataIndex in dataIndices {
+                guard let (negate, outIndex) = iterator.next() else {
+                    preconditionFailure("GaloisCoeffIterator goes out of index")
+                }
+                if negate {
+                    outputSpan[outputIndex(column: outIndex)] = dataSpan[dataIndex]
+                        .negateMod(modulus: modulus)
+                } else {
+                    outputSpan[outputIndex(column: outIndex)] = dataSpan[dataIndex]
                 }
             }
         }

--- a/Sources/ModularArithmetic/Modulus.swift
+++ b/Sources/ModularArithmetic/Modulus.swift
@@ -430,13 +430,11 @@ public struct MultiplyConstantArrayModulus<T: CoreScalarType>: Equatable, Sendab
 
     @inlinable
     public subscript(index: Int) -> MultiplyConstantModulus<T> {
-        factors.withUnsafeBufferPointer { factorPtr in
-            multiplicands.withUnsafeBufferPointer { multiplicandsPtr in
-                MultiplyConstantModulus(
-                    multiplicand: multiplicandsPtr[index],
-                    modulus: modulus,
-                    factor: factorPtr[index])
-            }
-        }
+        let factorSpan = factors.span
+        let multiplicandsSpan = multiplicands.span
+        return MultiplyConstantModulus(
+            multiplicand: multiplicandsSpan[index],
+            modulus: modulus,
+            factor: factorSpan[index])
     }
 }


### PR DESCRIPTION
This replaces a number of `withUnsafe` blocks with use of the `.span` property. This was introduced in Swift 6.2, so it does require bumping the toolchain version and minimum Mac deployment target.

Some minor performance regressions should be anticipated, as there will now be bounds checks performed where previously these were compiled out with the use of unsafe buffers. These either should be accepted as the cost of memory safety, or investigated to see if tweaks to the code structure could help the compiler eliminate them.