### PR TITLE
Add async * and - APIs

### DIFF
--- a/Snippets/HomomorphicEncryption/BasicsAsyncSnippet.swift
+++ b/Snippets/HomomorphicEncryption/BasicsAsyncSnippet.swift
@@ -72,13 +72,13 @@ precondition(decoded == [7, 15, 2, 2, 11, 0, 7, 15])
 
 // snippet.subtraction
 // We can subtract a plaintext from a ciphertext.
-try sum -= plaintext
+try await sum -= plaintext
 plaintextSum = try sum.decrypt(using: secretKey)
 decoded = try plaintextSum.decode(format: .coefficient)
 precondition(decoded == [16, 10, 7, 7, 13, 0, 16, 10])
 
 // We can also subtract a ciphertext from a ciphertext.
-try sum -= ciphertext
+try await sum -= ciphertext
 plaintextSum = try sum.decrypt(using: secretKey)
 decoded = try plaintextSum.decode(format: .coefficient)
 precondition(decoded == [8, 5, 12, 12, 15, 0, 8, 5])
@@ -86,7 +86,7 @@ precondition(decoded == [8, 5, 12, 12, 15, 0, 8, 5])
 // One special case is when subtracting a ciphertext from itself.
 // This yields a "transparent ciphertext", which reveals the underlying
 // plaintext to any observer. The observed value in this case is zero.
-try sum -= sum
+try  await sum -= sum
 precondition(sum.isTransparent())
 
 // snippet.hide

--- a/Sources/HomomorphicEncryption/Ciphertext.swift
+++ b/Sources/HomomorphicEncryption/Ciphertext.swift
@@ -600,6 +600,8 @@ extension Collection {
 // MARK: - Async ciphertext functions
 
 extension Ciphertext {
+    // MARK: - Async ciphertext + plaintext
+
     /// Async ciphertext-plaintext addition.
     /// - Parameters:
     ///   - plaintext: Plaintext to add.
@@ -629,6 +631,22 @@ extension Ciphertext {
         try await result += plaintext
         return result
     }
+
+    /// Async ciphertext-plaintext addition.
+    /// - Parameters:
+    ///   - ciphertext: Ciphertext to add to.
+    ///   - plaintext: Plaintext to add.
+    /// - Throws: Error upon failure to add.
+    @inlinable
+    public static func += (
+        ciphertext: inout Ciphertext<Scheme, Format>,
+        plaintext: Plaintext<Scheme, some PolyFormat>) async throws
+    {
+        try Scheme.validateEquality(of: ciphertext.context, and: plaintext.context)
+        try await Scheme.addAssignAsync(&ciphertext, plaintext)
+    }
+
+    // MARK: - Async ciphertext + ciphertext
 
     /// Async ciphertext addition.
     /// - Parameters:
@@ -661,20 +679,188 @@ extension Ciphertext {
         return result
     }
 
-    /// Async ciphertext addition.
+    // MARK: Async ciphertext -= ciphertext
+
+    /// Async ciphertext subtraction.
     /// - Parameters:
-    ///   - ciphertext: Ciphertext to add to.
-    ///   - plaintext: Plaintext to add.
-    /// - Throws: Error upon failure to add.
-    /// - seealso: ``Ciphertext/+=(_:_:)-8y0jp`` for a sync version.
+    ///   - lhs: Ciphertext to subtract from.
+    ///   - rhs: Plaintext to subtract.
+    /// - Returns: A ciphertext encrypting the difference `lhs - rhs'.
+    /// - Throws: Error upon failure to subtract.
     @inlinable
-    public static func += (
+    public static func - (lhs: Ciphertext<Scheme, Format>,
+                          rhs: Ciphertext<Scheme, some PolyFormat>) async throws -> Self
+    {
+        var result = lhs
+        try await result -= rhs
+        return result
+    }
+
+    // MARK: Async ciphertext - ciphertext
+
+    /// Async ciphertext subtraction.
+    /// - Parameters:
+    ///   - lhs: Ciphertext to subtract from.
+    ///   - rhs: Ciphertext to subtract.
+    /// - Throws: Error upon failure to subtract.
+    @inlinable
+    public static func -= (
+        lhs: inout Ciphertext<Scheme, Format>,
+        rhs: Ciphertext<Scheme, some PolyFormat>) async throws
+    {
+        try Scheme.validateEquality(of: lhs.context, and: rhs.context)
+        try await Scheme.subAssignAsync(&lhs, rhs)
+    }
+
+    // MARK: Async ciphertext - plaintext
+
+    /// Async ciphertext - plaintext
+    /// - Parameters:
+    ///   - ciphertext: Ciphertext to subtract from.
+    ///   - plaintext: Plaintext to subtract.
+    /// - Returns: A ciphertext encrypting the difference `ciphertext - plaintext`.
+    /// - Throws: Error upon failure to subtract.
+    @inlinable
+    public static func - (ciphertext: Ciphertext<Scheme, Format>,
+                          plaintext: Plaintext<Scheme, some PolyFormat>) async throws -> Self
+    {
+        var result = ciphertext
+        try await result -= plaintext
+        return result
+    }
+
+    // MARK: Async ciphertext -= plaintext
+
+    /// Async ciphertext -= plaintext
+    /// - Parameters:
+    ///   - ciphertext: Ciphertext to subtract from.
+    ///   - plaintext: Plaintext to subtract.
+    /// - Throws: Error upon failure to subtract.
+    @inlinable
+    public static func -= (
         ciphertext: inout Ciphertext<Scheme, Format>,
         plaintext: Plaintext<Scheme, some PolyFormat>) async throws
     {
         try Scheme.validateEquality(of: ciphertext.context, and: plaintext.context)
-        try await Scheme.addAssignAsync(&ciphertext, plaintext)
+        try await Scheme.subAssignAsync(&ciphertext, plaintext)
     }
+
+    // MARK: Async plaintext - ciphertext
+
+    /// Async plaintext - ciphertext.
+    /// - Parameters:
+    ///   - plaintext: Plaintext to subtract from.
+    ///   - ciphertext: Ciphertext to subtract.
+    /// - Returns: A ciphertext encrypting the difference `plaintext - ciphertext`.
+    /// - Throws: Error upon failure to subtract.
+    @inlinable
+    public static func - (
+        plaintext: Plaintext<Scheme, some PolyFormat>,
+        ciphertext: Ciphertext<Scheme, Format>) async throws -> Ciphertext<Scheme, Format>
+    {
+        try Scheme.validateEquality(of: ciphertext.context, and: plaintext.context)
+        return try await Scheme.subAsync(plaintext, ciphertext)
+    }
+
+    // MARK: Async ciphertext * ciphertext
+
+    /// Async ciphertext multiplication.
+    /// - Parameters:
+    ///   - lhs: Ciphertext to multiply.
+    ///   - rhs: Ciphertext to multiply.
+    /// - Returns: A ciphertext encrypting the product `lhs * rhs`.
+    /// - Throws: Error upon failure to multiply.
+    /// > Note: the values of the decrypted product depend on the ``EncodeFormat`` of the plaintexts encrypted by `lhs`
+    /// and `rhs.`
+    ///
+    /// > Important: The resulting ciphertext has 3 polynomials and can be relinearized. See
+    /// ``HeScheme/relinearize(_:using:)``
+    @inlinable
+    public static func * (lhs: Ciphertext<Scheme, Format>, rhs: Ciphertext<Scheme, Format>) async throws -> Self
+        where Format == Scheme.CanonicalCiphertextFormat
+    {
+        var result = lhs
+        try await result *= rhs
+        return result
+    }
+
+    // MARK: Async ciphertext * plaintext
+
+    /// Async ciphertext-plaintext multiplication.
+    /// - Parameters:
+    ///   - ciphertext: Ciphertext to multiply.
+    ///   - plaintext: Plaintext to multiply.
+    /// - Returns: A ciphertext encrypting the product `ciphertext * plaintext`.
+    /// - Throws: Error upon failure to multiply.
+    @inlinable
+    public static func * (ciphertext: Ciphertext<Scheme, Format>,
+                          plaintext: Plaintext<Scheme, Eval>) async throws -> Self
+        where Format == Eval
+    {
+        var result = ciphertext
+        try await result *= plaintext
+        return result
+    }
+
+    /// Async ciphertext-plaintext multiplication.
+    /// - Parameters:
+    ///   - ciphertext: Ciphertext to multiply.
+    ///   - plaintext: Plaintext to multiply.
+    /// - Returns: A ciphertext encrypting the product `ciphertext * plaintext`.
+    /// - Throws: Error upon failure to multiply.
+    @inlinable
+    public static func * (plaintext: Plaintext<Scheme, Eval>,
+                          ciphertext: Ciphertext<Scheme, Format>) async throws -> Self
+        where Format == Eval
+    {
+        try await ciphertext * plaintext
+    }
+
+    // MARK: Async ciphertext *= plaintext
+
+    /// Async ciphertext-plaintext multiplication.
+    /// - Parameters:
+    ///   - ciphertext: Ciphertext to multiply. Will store the product.
+    ///   - plaintext: Plaintext to multiply.
+    /// - Throws: Error upon failure to multiply.
+    @inlinable
+    public static func *= (
+        ciphertext: inout Ciphertext<Scheme, Format>,
+        plaintext: Plaintext<Scheme, Eval>) async throws
+        where Format == Eval
+    {
+        try Scheme.validateEquality(of: ciphertext.context, and: plaintext.context)
+        try await Scheme.mulAssignAsync(&ciphertext, plaintext)
+    }
+
+    // MARK: Async ciphertext *= ciphertext
+
+    /// Async ciphertext-ciphertext multiplication.
+    /// - Parameters:
+    ///   - lhs: Ciphertext to multiply. Will store the product.
+    ///   - rhs: Ciphertext to multiply.
+    /// - Throws: Error upon failure to multiply.
+    @inlinable
+    public static func *= (lhs: inout Ciphertext<Scheme, Format>, rhs: Ciphertext<Scheme, Format>) async throws
+        where Format == Scheme.CanonicalCiphertextFormat
+    {
+        try Scheme.validateEquality(of: lhs.context, and: rhs.context)
+        try await Scheme.mulAssignAsync(&lhs, rhs)
+    }
+
+    // MARK: Async ciphertext = -ciphertext
+
+    /// Async ciphertext negation.
+    /// - Parameter ciphertext: Ciphertext to negate.
+    /// - Returns: The negated ciphertext.
+    @inlinable
+    public static prefix func - (_ ciphertext: Ciphertext<Scheme, Format>) async -> Self {
+        var result = ciphertext
+        await Scheme.negAssignAsync(&result)
+        return result
+    }
+
+    // MARK: - Async ciphertext format conversion
 
     /// Converts the ciphertext to coefficient format asynchronously.
     ///

--- a/Sources/HomomorphicEncryption/HeSchemeAsync.swift
+++ b/Sources/HomomorphicEncryption/HeSchemeAsync.swift
@@ -295,4 +295,122 @@ extension HeScheme {
         }
         // swiftlint:enable force_cast
     }
+
+    /// In-place ciphertext-plaintext subtraction: `ciphertext -= plaintext`.
+    ///
+    /// - Parameters:
+    ///   - ciphertext: Ciphertext to subtract from; will store the difference.
+    ///   - plaintext: Plaintext to subtract.
+    /// - Throws: Error upon failure to subtract.
+    /// - seealso: ``HeScheme/subAssign(_:_:)-5gs6p`` for a sync version.
+    @inlinable
+    public static func subAssignAsync<CiphertextFormat: PolyFormat, PlaintextFormat: PolyFormat>(
+        _ ciphertext: inout Ciphertext<Self, CiphertextFormat>,
+        _ plaintext: Plaintext<Self, PlaintextFormat>) async throws
+    {
+        // swiftlint:disable force_cast
+        if CiphertextFormat.self == Coeff.self, PlaintextFormat.self == Coeff.self {
+            var coeffCiphertext = ciphertext as! CoeffCiphertext
+            try await subAssignCoeffAsync(&coeffCiphertext, plaintext as! CoeffPlaintext)
+            ciphertext = coeffCiphertext as! Ciphertext<Self, CiphertextFormat>
+        } else if CiphertextFormat.self == Eval.self, PlaintextFormat.self == Eval.self {
+            var evalCiphertext = ciphertext as! EvalCiphertext
+            try await subAssignEvalAsync(&evalCiphertext, plaintext as! EvalPlaintext)
+            ciphertext = evalCiphertext as! Ciphertext<Self, CiphertextFormat>
+        } else {
+            throw HeError.unsupportedHeOperation(
+                """
+                Subtraction between ciphertext in \(CiphertextFormat.description) \
+                and plaintext in \(PlaintextFormat.description).
+                """)
+        }
+        // swiftlint:enable force_cast
+    }
+
+    /// Plaintext-ciphertext subtraction: `plaintext - ciphertext`.
+    ///
+    /// - Parameters:
+    ///   - plaintext: Plaintext to subtract from.
+    ///   - ciphertext: Ciphertext to subtract.
+    /// - Returns: A ciphertext encrypting the difference.
+    /// - Throws: Error upon failure to subtract.
+    /// - seealso: ``HeScheme/sub(_:_:)-4xfo4`` for a sync version.
+    @inlinable
+    public static func subAsync<CiphertextFormat: PolyFormat, PlaintextFormat: PolyFormat>(
+        _ plaintext: Plaintext<Self, PlaintextFormat>,
+        _ ciphertext: Ciphertext<Self, CiphertextFormat>) async throws -> Ciphertext<Self, CiphertextFormat>
+    {
+        // swiftlint:disable force_cast
+        if CiphertextFormat.self == Coeff.self, PlaintextFormat.self == Coeff.self {
+            let coeffCiphertext = ciphertext as! CoeffCiphertext
+            let coeffPlaintext = plaintext as! CoeffPlaintext
+            return try await subCoeffAsync(coeffPlaintext, coeffCiphertext) as! Ciphertext<Self, CiphertextFormat>
+        }
+        if CiphertextFormat.self == Eval.self, PlaintextFormat.self == Eval.self {
+            let evalCiphertext = ciphertext as! EvalCiphertext
+            let evalPlaintext = plaintext as! EvalPlaintext
+            return try await subEvalAsync(evalPlaintext, evalCiphertext) as! Ciphertext<Self, CiphertextFormat>
+        }
+        throw HeError.unsupportedHeOperation("""
+            Subtraction between plaintext in \(PlaintextFormat.description) and \
+            ciphertext in \(CiphertextFormat.description).
+            """)
+        // swiftlint:enable force_cast
+    }
+
+    /// In-place ciphertext subtraction: `lhs -= rhs`.
+    ///
+    /// - Parameters:
+    ///   - lhs: Ciphertext to subtract from; will store the difference.
+    ///   - rhs: Ciphertext to subtract.
+    /// - Throws: Error upon failure to subtract.
+    /// - seealso: ``HeScheme/subAssign(_:_:)-75ktc`` for a sync version.
+    @inlinable
+    public static func subAssignAsync<LhsFormat: PolyFormat, RhsFormat: PolyFormat>(
+        _ lhs: inout Ciphertext<Self, LhsFormat>,
+        _ rhs: Ciphertext<Self, RhsFormat>) async throws
+    {
+        // swiftlint:disable force_cast
+        if LhsFormat.self == Coeff.self {
+            var lhsCoeffCiphertext = lhs as! CoeffCiphertext
+            if RhsFormat.self == Coeff.self {
+                try await subAssignCoeffAsync(&lhsCoeffCiphertext, rhs as! CoeffCiphertext)
+            } else {
+                fatalError("Unsupported Format \(RhsFormat.description)")
+            }
+            lhs = lhsCoeffCiphertext as! Ciphertext<Self, LhsFormat>
+        } else if LhsFormat.self == Eval.self {
+            var lhsEvalCiphertext = lhs as! EvalCiphertext
+            if RhsFormat.self == Eval.self {
+                try await subAssignEvalAsync(&lhsEvalCiphertext, rhs as! EvalCiphertext)
+            } else {
+                fatalError("Unsupported Format \(RhsFormat.description)")
+            }
+            lhs = lhsEvalCiphertext as! Ciphertext<Self, LhsFormat>
+        } else {
+            fatalError("Unsupported Format \(LhsFormat.description)")
+        }
+        // swiftlint:enable force_cast
+    }
+
+    /// In-place ciphertext negation: `ciphertext = -ciphertext`.
+    ///
+    /// - Parameter ciphertext: Ciphertext to negate.
+    /// - seealso: ``HeScheme/negAssign(_:)`` for a sync version.
+    @inlinable
+    public static func negAssignAsync<Format: PolyFormat>(_ ciphertext: inout Ciphertext<Self, Format>) async {
+        // swiftlint:disable force_cast
+        if Format.self == Coeff.self {
+            var coeffCiphertext = ciphertext as! CoeffCiphertext
+            await negAssignCoeffAsync(&coeffCiphertext)
+            ciphertext = coeffCiphertext as! Ciphertext<Self, Format>
+        } else if Format.self == Eval.self {
+            var evalCiphertext = ciphertext as! EvalCiphertext
+            await negAssignEvalAsync(&evalCiphertext)
+            ciphertext = evalCiphertext as! Ciphertext<Self, Format>
+        } else {
+            fatalError("Unsupported Format \(Format.description)")
+        }
+        // swiftlint:enable force_cast
+    }
 }

--- a/Sources/PrivateInformationRetrieval/IndexPir/PirUtil.swift
+++ b/Sources/PrivateInformationRetrieval/IndexPir/PirUtil.swift
@@ -96,12 +96,11 @@ extension PirUtilProtocol {
         }
         precondition(currElement == targetElement)
 
-        var difference = ciphertext
-        try await Scheme.subAssignAsync(&difference, c1)
+        let difference = try await ciphertext - c1
         var differenceCoeff = try await difference.convertToCoeffFormat()
         try await Scheme.multiplyPowerOfXAsync(&differenceCoeff, power: -shiftingPower)
         let differenceCanonical = try await differenceCoeff.convertToCanonicalFormat()
-        try await Scheme.addAssignAsync(&c1, ciphertext)
+        try await c1 += ciphertext
         return (c1, differenceCanonical)
     }
 
@@ -129,7 +128,7 @@ extension PirUtilProtocol {
             if logStep > expectedHeight {
                 return [ciphertext]
             }
-            try await Scheme.addAssignAsync(&output, ciphertext)
+            try await output += ciphertext
             return [output]
         }
         let secondHalfCount = outputCount >> 1

--- a/Sources/PrivateNearestNeighborSearch/CiphertextMatrix.swift
+++ b/Sources/PrivateNearestNeighborSearch/CiphertextMatrix.swift
@@ -327,7 +327,7 @@ extension CiphertextMatrix {
         }()
 
         var ciphertextEval = try await ciphertexts[ciphertextIndex].convertToEvalFormat()
-        try await Scheme.mulAssignAsync(&ciphertextEval, plaintextMask)
+        try await ciphertextEval *= plaintextMask
         var ciphertext = try await ciphertextEval.convertToCanonicalFormat()
         // e.g., `ciphertext` now encrypts
         // [[0, 0, 3, 4, 0, 0, 3, 4],
@@ -341,7 +341,7 @@ extension CiphertextMatrix {
                 of: &ciphertextCopyRight,
                 by: columnCountPowerOfTwo,
                 using: evaluationKey)
-            try await Scheme.addAssignAsync(&ciphertext, ciphertextCopyRight)
+            try await ciphertext += ciphertextCopyRight
         }
         // e.g., `ciphertext` now encrypts
         // [[3, 4, 3, 4, 3, 4, 3, 4],
@@ -350,7 +350,7 @@ extension CiphertextMatrix {
         // Duplicate values to both SIMD rows
         var ciphertextCopy = ciphertext
         try await Scheme.swapRowsAsync(of: &ciphertextCopy, using: evaluationKey)
-        try await Scheme.addAssignAsync(&ciphertext, ciphertextCopy)
+        try await ciphertext += ciphertextCopy
         // e.g., `ciphertext` now encrypts
         // [[3, 4, 3, 4, 3, 4, 3, 4],
         //  [3, 4, 3, 4, 3, 4, 3, 4]]

--- a/Sources/_TestUtilities/TestUtilities.swift
+++ b/Sources/_TestUtilities/TestUtilities.swift
@@ -26,6 +26,7 @@ import Testing
 ///   - absoluteTolerance: An optional absolute tolerance to enforce.
 /// - Returns: true if the expressions are close to each other
 extension BinaryFloatingPoint {
+    @inlinable
     package func isClose(to value: Self,
                          relativeTolerance: Self = Self(1e-5),
                          absoluteTolerance: Self = Self(1e-8)) -> Bool

--- a/Tests/HomomorphicEncryptionTests/HeAPITests.swift
+++ b/Tests/HomomorphicEncryptionTests/HeAPITests.swift
@@ -87,28 +87,31 @@ struct HeAPITests {
     @Test
     func noOpScheme() async throws {
         let context: Context<NoOpScheme> = try TestUtils.getTestContext()
+        // Sync tests
+        // swiftlint:disable line_length
+        // swiftformat:disable wrap wrapArguments
         try HeAPITestHelpers.schemeEncodeDecodeTest(context: context, scheme: NoOpScheme.self)
         try HeAPITestHelpers.schemeEncryptDecryptTest(context: context, scheme: NoOpScheme.self)
         try HeAPITestHelpers.schemeEncryptZeroDecryptTest(context: context, scheme: NoOpScheme.self)
-        try HeAPITestHelpers.schemeEncryptZeroAddDecryptTest(context: context, scheme: NoOpScheme.self)
-        try HeAPITestHelpers.schemeEncryptZeroMultiplyDecryptTest(context: context, scheme: NoOpScheme.self)
+        try HeAPITestHelpers.schemeEvaluationKeyTest(context: context)
+
+        // Async tests
+        try await HeAPITestHelpers.schemeEncryptZeroAddDecryptTest(context: context, scheme: NoOpScheme.self)
+        try await HeAPITestHelpers.schemeEncryptZeroMultiplyDecryptTest(context: context, scheme: NoOpScheme.self)
         try await HeAPITestHelpers.schemeCiphertextAdditionTest(context: context, scheme: NoOpScheme.self)
         try await HeAPITestHelpers.schemeCiphertextSubtractionTest(context: context, scheme: NoOpScheme.self)
-        try await HeAPITestHelpers.schemeCiphertextCiphertextMultiplicationTest(
-            context: context,
-            scheme: NoOpScheme.self)
+        try await HeAPITestHelpers.schemeCiphertextCiphertextMultiplicationTest(context: context, scheme: NoOpScheme.self)
         try await HeAPITestHelpers.schemeCiphertextPlaintextAdditionTest(context: context, scheme: NoOpScheme.self)
         try await HeAPITestHelpers.schemeCiphertextPlaintextSubtractionTest(context: context, scheme: NoOpScheme.self)
-        try await HeAPITestHelpers.schemeCiphertextPlaintextMultiplicationTest(
-            context: context,
-            scheme: NoOpScheme.self)
+        try await HeAPITestHelpers.schemeCiphertextPlaintextMultiplicationTest(context: context, scheme: NoOpScheme.self)
         try await HeAPITestHelpers.schemeCiphertextMultiplyAddTest(context: context, scheme: NoOpScheme.self)
-        try HeAPITestHelpers.schemeCiphertextMultiplyAddPlainTest(context: context, scheme: NoOpScheme.self)
+        try await HeAPITestHelpers.schemeCiphertextMultiplyAddPlainTest(context: context, scheme: NoOpScheme.self)
         try await HeAPITestHelpers.schemeCiphertextMultiplySubTest(context: context, scheme: NoOpScheme.self)
         try await HeAPITestHelpers.schemeCiphertextNegateTest(context: context, scheme: NoOpScheme.self)
-        try HeAPITestHelpers.schemeEvaluationKeyTest(context: context)
         try await HeAPITestHelpers.schemeRotationTest(context: context, scheme: NoOpScheme.self)
         try await HeAPITestHelpers.schemeApplyGaloisTest(context: context, scheme: NoOpScheme.self)
+        // swiftlint:enable line_length
+        // swiftformat:enable wrap wrapArguments
     }
 
     private func bfvTestKeySwitching<T>(context: Context<Bfv<T>>) throws {
@@ -169,41 +172,46 @@ struct HeAPITests {
 
         for encryptionParameters in predefined + [custom, manyModuli] {
             let context = try Context<Bfv<T>>(encryptionParameters: encryptionParameters)
+            // Sync tests
             try HeAPITestHelpers.schemeEncodeDecodeTest(context: context, scheme: Bfv<T>.self)
             try HeAPITestHelpers.schemeEncryptDecryptTest(context: context, scheme: Bfv<T>.self)
             try HeAPITestHelpers.schemeEncryptZeroDecryptTest(context: context, scheme: Bfv<T>.self)
-            try HeAPITestHelpers.schemeEncryptZeroAddDecryptTest(context: context, scheme: Bfv<T>.self)
-            try HeAPITestHelpers.schemeEncryptZeroMultiplyDecryptTest(context: context, scheme: Bfv<T>.self)
+            try HeAPITestHelpers.schemeEvaluationKeyTest(context: context)
+            try HeAPITestHelpers.noiseBudgetTest(context: context, scheme: Bfv<T>.self)
+
+            // BFV tests
+            try bfvTestKeySwitching(context: context)
+
+            // Async tests
+            // swiftlint:disable line_length
+            // swiftformat:disable wrap wrapArguments
+            try await HeAPITestHelpers.schemeEncryptZeroAddDecryptTest(context: context, scheme: Bfv<T>.self)
+            try await HeAPITestHelpers.schemeEncryptZeroMultiplyDecryptTest(context: context, scheme: Bfv<T>.self)
             try await HeAPITestHelpers.schemeCiphertextAdditionTest(context: context, scheme: Bfv<T>.self)
             try await HeAPITestHelpers.schemeCiphertextSubtractionTest(context: context, scheme: Bfv<T>.self)
             try await HeAPITestHelpers.schemeCiphertextPlaintextAdditionTest(context: context, scheme: Bfv<T>.self)
-            // swiftformat:disable wrap wrapArguments
             try await HeAPITestHelpers.schemeCiphertextPlaintextSubtractionTest(context: context, scheme: Bfv<T>.self)
-            // swiftlint:disable line_length
             try await HeAPITestHelpers.schemeCiphertextPlaintextMultiplicationTest(context: context, scheme: Bfv<T>.self)
             try await HeAPITestHelpers.schemeCiphertextMultiplySubtractPlainTest(context: context, scheme: Bfv<T>.self)
             try await HeAPITestHelpers.schemeCiphertextPlaintextMultiplyAddPlainTest(context: context, scheme: Bfv<T>.self)
             try await HeAPITestHelpers.schemeCiphertextPlaintextMultiplySubtractPlainTest(context: context, scheme: Bfv<T>.self)
-            try HeAPITestHelpers.schemeCiphertextMultiplyAddPlainTest(context: context, scheme: Bfv<T>.self)
+            try await HeAPITestHelpers.schemeCiphertextMultiplyAddPlainTest(context: context, scheme: Bfv<T>.self)
             try await HeAPITestHelpers.schemeCiphertextMultiplySubtractPlainTest(context: context, scheme: Bfv<T>.self)
             try await HeAPITestHelpers.schemeCiphertextPlaintextMultiplyAddPlainTest(context: context, scheme: Bfv<T>.self)
             try await HeAPITestHelpers.schemeCiphertextPlaintextMultiplySubtractPlainTest(context: context, scheme: Bfv<T>.self)
             try await HeAPITestHelpers.schemeCiphertextCiphertextMultiplicationTest(context: context, scheme: Bfv<T>.self)
-            // swiftlint:enable line_length
             try await HeAPITestHelpers.schemeCiphertextPlaintextInnerProductTest(context: context, scheme: Bfv<T>.self)
             try await HeAPITestHelpers.schemeCiphertextCiphertextInnerProductTest(context: context, scheme: Bfv<T>.self)
-            // swiftformat:enable wrap wrapArguments
             try await HeAPITestHelpers.schemeCiphertextMultiplyAddTest(context: context, scheme: Bfv<T>.self)
             try await HeAPITestHelpers.schemeCiphertextNegateTest(context: context, scheme: Bfv<T>.self)
-            try HeAPITestHelpers.schemeEvaluationKeyTest(context: context)
             try await HeAPITestHelpers.schemeApplyGaloisTest(context: context, scheme: Bfv<T>.self)
             try await HeAPITestHelpers.schemeRotationTest(context: context, scheme: Bfv<T>.self)
-            try bfvTestKeySwitching(context: context)
-            try HeAPITestHelpers.noiseBudgetTest(context: context, scheme: Bfv<T>.self)
             try await HeAPITestHelpers.repeatedAdditionTest(context: context, scheme: Bfv<T>.self)
             try await HeAPITestHelpers.multiplyPowerOfXTest(context: context, scheme: Bfv<T>.self)
             try await HeAPITestHelpers.schemeTestNtt(context: context, scheme: Bfv<T>.self)
             try await HeAPITestHelpers.schemeTestFormats(context: context, scheme: Bfv<T>.self)
+            // swiftlint:enable line_length
+            // swiftformat:enable wrap wrapArguments
         }
     }
 


### PR DESCRIPTION
Similar to https://github.com/apple/swift-homomorphic-encryption/pull/250, adds some more Ciphertext async APIs for `*` and `-`