### PR TITLE
Fix benchmark visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ env:
   # Keep versions in sync with README
   SWIFTLINT_VERSION: 0.62.2
   SWIFTFORMAT_VERSION: 0.58.6
-  SWIFT_HOMOMORPHIC_ENCRYPTION_ENABLE_BENCHMARKING: 1
 jobs:
   soundness:
     name: soundness
@@ -34,6 +33,7 @@ jobs:
     with:
       enable_windows_checks: false
       linux_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}, {\"swift_version\": \"5.10\"}]"
+      linux_env_vars: SWIFT_HOMOMORPHIC_ENCRYPTION_ENABLE_BENCHMARKING=1
       linux_pre_build_command: "apt-get update && apt-get install -y libjemalloc-dev"
       linux_build_command: >
         swift test --configuration release;

--- a/Benchmarks/PolyBenchmark/PolyBenchmark.swift
+++ b/Benchmarks/PolyBenchmark/PolyBenchmark.swift
@@ -16,8 +16,8 @@
 // These benchmarks can be triggered with
 // SWIFT_HOMOMORPHIC_ENCRYPTION_ENABLE_BENCHMARKING=1 swift package benchmark --target PolyBenchmark
 
-import Benchmark
-import HomomorphicEncryption
+public import Benchmark
+public import HomomorphicEncryption
 
 @usableFromInline nonisolated(unsafe) let benchmarkConfiguration = Benchmark.Configuration(
     metrics: [.wallClock, .mallocCountTotal, .peakMemoryResident],

--- a/Benchmarks/RlweBenchmark/RlweBenchmark.swift
+++ b/Benchmarks/RlweBenchmark/RlweBenchmark.swift
@@ -16,8 +16,8 @@
 // These benchmarks can be triggered with
 // SWIFT_HOMOMORPHIC_ENCRYPTION_ENABLE_BENCHMARKING=1 swift package benchmark --target RlweBenchmark
 
-import Benchmark
-import HomomorphicEncryption
+public import Benchmark
+public import HomomorphicEncryption
 
 @usableFromInline nonisolated(unsafe) let benchmarkConfiguration = Benchmark.Configuration(
     metrics: [.wallClock, .mallocCountTotal, .peakMemoryResident],

--- a/Sources/_BenchmarkUtilities/BenchmarkMetricExtensions.swift
+++ b/Sources/_BenchmarkUtilities/BenchmarkMetricExtensions.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import Benchmark
-import HomomorphicEncryption
+public import HomomorphicEncryption
 
 let noiseBudgetScale = 10
 

--- a/Sources/_BenchmarkUtilities/PirBenchmarkUtilities.swift
+++ b/Sources/_BenchmarkUtilities/PirBenchmarkUtilities.swift
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 import ApplicationProtobuf
-import Benchmark
+public import Benchmark
 import Foundation
-import HomomorphicEncryption
+public import HomomorphicEncryption
 import HomomorphicEncryptionProtobuf
-import PrivateInformationRetrieval
+public import PrivateInformationRetrieval
 
 @usableFromInline nonisolated(unsafe) let pirBenchmarkConfiguration = Benchmark.Configuration(
     metrics: [

--- a/Sources/_BenchmarkUtilities/PnnsBenchmarkUtilities.swift
+++ b/Sources/_BenchmarkUtilities/PnnsBenchmarkUtilities.swift
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 import ApplicationProtobuf
-import Benchmark
+public import Benchmark
 import Foundation
-import HomomorphicEncryption
+public import HomomorphicEncryption
 import HomomorphicEncryptionProtobuf
 import PrivateNearestNeighborSearch
 


### PR DESCRIPTION
Adopting `InternalImportsByDefault ` in https://github.com/apple/swift-homomorphic-encryption/pull/248 broke the benchmarks.

This PR fixes the benchmarks & updates CI to compile benchmarks again. Some upstream github-workflows commit must've broken the benchmarking CI at some point. The expected failing CI in https://github.com/apple/swift-homomorphic-encryption/pull/253 shows we're compiling benchmarks now.