### PR TITLE
Make Pir/Pnns utilities Sendable

### DIFF
--- a/Sources/_BenchmarkUtilities/BenchmarkMetricExtensions.swift
+++ b/Sources/_BenchmarkUtilities/BenchmarkMetricExtensions.swift
@@ -28,16 +28,16 @@ extension BenchmarkMetric {
 }
 
 /// Encryption parameters configuration for benchmarks.
-public struct EncryptionParametersConfig {
+public struct EncryptionParametersConfig: Sendable {
     /// Default configuration for PNNS benchmarks
-    public nonisolated(unsafe) static let defaultPnns = EncryptionParametersConfig(
+    public static let defaultPnns = EncryptionParametersConfig(
         polyDegree: 4096,
         // use plaintextModulusBits: [16, 17] for plaintext CRT
         plaintextModulusBits: [17],
         coefficientModulusBits: [27, 28, 28])
 
     /// Default configuration for PIR benchmarks
-    public nonisolated(unsafe) static let defaultPir = EncryptionParametersConfig(
+    public static let defaultPir = EncryptionParametersConfig(
         polyDegree: 4096,
         plaintextModulusBits: [5],
         coefficientModulusBits: [27, 28, 28])

--- a/Sources/_BenchmarkUtilities/PirBenchmarkUtilities.swift
+++ b/Sources/_BenchmarkUtilities/PirBenchmarkUtilities.swift
@@ -44,7 +44,7 @@ func getDatabaseForTesting(
 }
 
 /// Configuration for a PIR database.
-public struct PirDatabaseConfig {
+public struct PirDatabaseConfig: Sendable {
     /// Number of rows in the database.
     public let entryCount: Int
     /// Size of each entry in bytes.

--- a/Sources/_BenchmarkUtilities/PnnsBenchmarkUtilities.swift
+++ b/Sources/_BenchmarkUtilities/PnnsBenchmarkUtilities.swift
@@ -59,7 +59,7 @@ public struct PnnsBenchmarkConfig {
 }
 
 /// Configuration for a PNNS database.
-public struct PnnsDatabaseConfig {
+public struct PnnsDatabaseConfig: Sendable {
     /// Number of rows in the database.
     public let rowCount: Int
     /// Dimension of each embedding vector.


### PR DESCRIPTION
Make `EncryptionParametersConfig, PirDatabaseConfig, PnnsDatabaseConfig` Sendable, so that we can omit `nonisolated(unsafe)` when creating custom benchmark configs.

E.g. we can now omit ``nonisolated(unsafe)` from the below:
```swift
nonisolated(unsafe) let encryptionConfig = EncryptionParametersConfig(
    polyDegree: 4096,
    plaintextModulusBits: [5],
    coefficientModulusBits: [27, 28, 28])
```