### PR TITLE
PIRGenerateDatabase supports index database

### DIFF
--- a/Sources/PIRGenerateDatabase/PIRGenerateDatabase.docc/PIRGenerateDatabase.md
+++ b/Sources/PIRGenerateDatabase/PIRGenerateDatabase.docc/PIRGenerateDatabase.md
@@ -26,6 +26,7 @@ swift package experimental-install -c release --product PIRGenerateDatabase
 1. We start by generating a sample database.
 ```sh
 PIRGenerateDatabase \
+    --database-type keyword \
     --output-database database.txtpb \
     --row-count 100 \
     --value-size '10...20' \
@@ -36,6 +37,8 @@ This will generate a database of 100 rows, with keywords 0 to 99, and each value
 
 The database is a serialized [Apple_SwiftHomomorphicEncryption_Pir_V1_KeywordDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/applicationprotobuf/apple_swifthomomorphicencryption_pir_v1_keyworddatabase).
 For readability, the `.txtpb` extension ensures the output database will be saved in protocol buffer text format.
+
+> Note: Pass `--database-type index` to instead generate a serialized [Apple_SwiftHomomorphicEncryption_Pir_V1_IndexPirDatabase](https://swiftpackageindex.com/apple/swift-homomorphic-encryption/main/documentation/applicationprotobuf/apple_swifthomomorphicencryption_pir_v1_indexpirdatabase).
 
 > Note: For a more compact format, use the `.binpb` extension to save the database in protocol buffer binary format.
 

--- a/Sources/PIRProcessDatabase/PIRProcessDatabase.docc/ReusingPirParameters.md
+++ b/Sources/PIRProcessDatabase/PIRProcessDatabase.docc/ReusingPirParameters.md
@@ -31,6 +31,7 @@ swift package experimental-install -c release --product PIRGenerateDatabase --pr
 
 ```sh
 PIRGenerateDatabase \
+    --database-type keyword \
     --output-database /tmp/database-v1.txtpb \
     --row-count 10000 \
     --value-size '10...20' \
@@ -58,8 +59,9 @@ rows {
 ```
 
 2. To simulate an updated database, we generate a database update with 1000 more rows and different value sizes.
-```
+```sh
 PIRGenerateDatabase \
+    --database-type keyword \
     --output-database /tmp/database-update.txtpb \
     --row-count 1000 \
     --first-keyword 10000 \

--- a/Sources/PIRShardDatabase/PIRShardDatabase.docc/PIRShardDatabase.md
+++ b/Sources/PIRShardDatabase/PIRShardDatabase.docc/PIRShardDatabase.md
@@ -34,7 +34,9 @@ swift package experimental-install -c release --product PIRGenerateDatabase --pr
 
 1. We start by generating a sample database.
 ```sh
-PIRGenerateDatabase --output-database database.txtpb \
+PIRGenerateDatabase \
+    --database-type keyword \
+    --output-database database.txtpb \
     --row-count 100 \
     --value-size '10..<20' \
     --value-type repeated

--- a/Sources/PrivateInformationRetrieval/PrivateInformationRetrieval.docc/ParameterTuning.md
+++ b/Sources/PrivateInformationRetrieval/PrivateInformationRetrieval.docc/ParameterTuning.md
@@ -87,6 +87,7 @@ executables.
 We generate a database of 100,000 rows, each with 2 bytes.
 ```sh
 PIRGenerateDatabase \
+    --database-type keyword \
     --output-database thinDatabase.txtpb \
     --row-count 100000 \
     --value-size 2 \
@@ -122,8 +123,9 @@ keyword-value pairs, making the database smaller for keyword PIR.
 
 #### Wide Database
 We generate a database of 1000 rows, each with 60,000 bytes.
-```json
+```sh
 PIRGenerateDatabase \
+    --database-type keyword \
     --output-database wideDatabase.txtpb \
     --row-count 1000 \
     --value-size 60000 \

--- a/Sources/PrivateInformationRetrieval/PrivateInformationRetrieval.docc/ReusingPirParameters.md
+++ b/Sources/PrivateInformationRetrieval/PrivateInformationRetrieval.docc/ReusingPirParameters.md
@@ -31,6 +31,7 @@ swift package experimental-install -c release --product PIRGenerateDatabase  --p
 
 ```sh
 PIRGenerateDatabase \
+    --database-type keyword \
     --output-database /tmp/database-v1.txtpb \
     --row-count 10000 \
     --value-size '10...20' \
@@ -58,8 +59,9 @@ rows {
 ```
 
 2. To simulate an updated database, we generate a database update with a few more rows and different value sizes
-```
+```sh
 PIRGenerateDatabase \
+    --database-type keyword \
     --output-database /tmp/database-update.txtpb \
     --row-count 1000 \
     --first-keyword 10000 \

--- a/Tests/PIRGenerateDatabaseTests/PIRGenerateDatabaseTests.swift
+++ b/Tests/PIRGenerateDatabaseTests/PIRGenerateDatabaseTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2026 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ import Testing
 @Suite
 struct PIRGenerateDatabaseTests {
     @Test
-    func valueSizeArguments() throws {
-        #expect(try #require(ValueSizeArguments(argument: "1")?.range) == 1..<2)
-        #expect(try #require(ValueSizeArguments(argument: "1..<10")?.range) == 1..<10)
-        #expect(try #require(ValueSizeArguments(argument: "1...10")?.range) == 1..<11)
+    func valueSizeArgument() throws {
+        #expect(try #require(ValueSizeArgument(argument: "1")?.range) == 1..<2)
+        #expect(try #require(ValueSizeArgument(argument: "1..<10")?.range) == 1..<10)
+        #expect(try #require(ValueSizeArgument(argument: "1...10")?.range) == 1..<11)
     }
 }


### PR DESCRIPTION
Adds a required `database-type` argument to `PIRGenerateDatabase`, which can be used to generate an IndexPir database.

E.g. usage:
`PIRGenerateDatabase --database-type index --output-database database.txtpb --row-count 10000 --value-size 50000...60000 --value-type repeated`