### PR TITLE
Remove evaluationKeyConfig from ProcessedDatabaseWithParameters init

### DIFF
--- a/Sources/ApplicationProtobuf/PirConversion.swift
+++ b/Sources/ApplicationProtobuf/PirConversion.swift
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2026 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -188,7 +188,6 @@ extension Apple_SwiftHomomorphicEncryption_Pir_V1_PirParameters {
         try ProcessedDatabaseWithParameters(
             database: database,
             algorithm: algorithm.native(),
-            evaluationKeyConfig: evaluationKeyConfig.native(),
             pirParameter: native(),
             keywordPirParameter: hasKeywordPirParams ? keywordPirParams.native() : nil)
     }

--- a/Sources/PrivateInformationRetrieval/IndexPir/IndexPirProtocol.swift
+++ b/Sources/PrivateInformationRetrieval/IndexPir/IndexPirProtocol.swift
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2026 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -262,8 +262,6 @@ public struct ProcessedDatabaseWithParameters<Scheme: HeScheme>: Equatable, Send
     public let database: ProcessedDatabase<Scheme>
     /// The algorithm that this database was processed for.
     public let algorithm: PirAlgorithm
-    /// Evaluation key configuration.
-    public let evaluationKeyConfig: EvaluationKeyConfig
     /// Parameters for Index PIR queries.
     public let pirParameter: IndexPirParameter
     /// Parameters for keyword-value PIR queries.
@@ -271,25 +269,27 @@ public struct ProcessedDatabaseWithParameters<Scheme: HeScheme>: Equatable, Send
     /// Symmetric PIR config.
     public let symmetricPirConfig: SymmetricPirConfig?
 
+    /// Evaluation key configuration.
+    public var evaluationKeyConfig: EvaluationKeyConfig {
+        pirParameter.evaluationKeyConfig
+    }
+
     /// Initializes a ``ProcessedDatabaseWithParameters``.
     /// - Parameters:
     ///   - database: Processed database.
     ///   - algorithm: The PIR algorithm used.
-    ///   - evaluationKeyConfig: Evaluation key configuration.
     ///   - pirParameter: Index PIR parameters.
     ///   - keywordPirParameter: Optional keyword PIR parameters.
     ///   - symmetricPirConfig: Optional config for symmetric PIR.
     public init(
         database: ProcessedDatabase<Scheme>,
         algorithm: PirAlgorithm,
-        evaluationKeyConfig: EvaluationKeyConfig,
         pirParameter: IndexPirParameter,
         keywordPirParameter: KeywordPirParameter? = nil,
         symmetricPirConfig: SymmetricPirConfig? = nil)
     {
         self.database = database
         self.algorithm = algorithm
-        self.evaluationKeyConfig = evaluationKeyConfig
         self.pirParameter = pirParameter
         self.keywordPirParameter = keywordPirParameter
         self.symmetricPirConfig = symmetricPirConfig

--- a/Sources/PrivateInformationRetrieval/KeywordPir/KeywordPirProtocol.swift
+++ b/Sources/PrivateInformationRetrieval/KeywordPir/KeywordPirProtocol.swift
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2026 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -231,12 +231,10 @@ public final class KeywordPirServer<PirServer: IndexPirServer>: KeywordPirProtoc
             plaintexts.append(contentsOf: temp)
         }
         let processedDb = PirServer.Database(plaintexts: plaintexts)
-        let evaluationKeyConfig = indexPirParameter.evaluationKeyConfig
 
         return ProcessedDatabaseWithParameters(
             database: processedDb,
             algorithm: PirServer.IndexPir.algorithm,
-            evaluationKeyConfig: evaluationKeyConfig,
             pirParameter: indexPirParameter,
             keywordPirParameter: config.parameter,
             symmetricPirConfig: symmetricPirConfig)


### PR DESCRIPTION
`ProcessedDatabaseWithParameters` init doesn't need `evaluationKeyConfig`, since it's already part of `pirParameter`.

Note, the `evaluationKeyConfig` union over the shards happens at https://github.com/apple/swift-homomorphic-encryption/blob/3a0555ca28eec6b95ffce12ac860532963ad2517/Sources/PrivateInformationRetrieval/KeywordPir/KeywordDatabase.swift#L620-L624, should be affected.

```
  💔 API breakage: constructor ProcessedDatabaseWithParameters.init(database:algorithm:evaluationKeyConfig:pirParameter:keywordPirParameter:symmetricPirConfig:) has been removed
```