### PR TITLE
Fix SPI build: add SPI_GENERATE_DOCS=1 flag to enable swift-docc-plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 // Remember to update CI if changing
 
-// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2026 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -334,11 +334,13 @@ if enableBenchmarking {
 // MARK: - DoCC plugin
 
 var enableDocCPlugin: Bool {
-    let benchmarkFlags = "SWIFT_HOMOMORPHIC_ENCRYPTION_ENABLE_DOCCPLUGIN"
-    if let flag = ProcessInfo.processInfo.environment[benchmarkFlags], flag == "1" {
-        return true
-    }
-    return false
+    let env = ProcessInfo.processInfo.environment
+    // Workaround to ensure that swift-docc-plugin is included. Swift Package Index adds
+    // SPI_GENERATE_DOCS (https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2336)
+    // when building documentation.
+    let spiGenerateDocs = env["SPI_GENERATE_DOCS"] ?? "" == "1"
+    let enableDocs = env["SWIFT_HOMOMORPHIC_ENCRYPTION_ENABLE_DOCCPLUGIN"] ?? "" == "1"
+    return spiGenerateDocs || enableDocs
 }
 
 if enableDocCPlugin {


### PR DESCRIPTION
Our SPI builds have been failing on `main`, probably due to removing Swift Docc plugin by default: https://github.com/apple/swift-homomorphic-encryption/pull/240.

The roots cause is SPI has a grep for `"https://github.com/swiftlang/swift-docc-plugin"`, as noted in https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/3061#issuecomment-2118686573.
The grep isn't smart enough to realize our `swift-docc-plugin` dep is gated behind a opt-in flag, so SPI doesn't add in the `swift-docc-plugin`.

The recommendation seems to be to use the `SPI_GENERATE_DOCS=1` flag (e.g. https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/3061#issuecomment-2118879821)

So hopefully this fixes the SPI build issues.