### PR TITLE
add missing entry for encoding entry size

### DIFF
--- a/Sources/ApplicationProtobuf/PirConversion.swift
+++ b/Sources/ApplicationProtobuf/PirConversion.swift
@@ -69,6 +69,7 @@ extension ProcessedDatabaseWithParameters {
             params.evaluationKeyConfig = try evaluationKeyConfig
                 .proto(encryptionParameters: encryptionParameters, scheme: Scheme.self)
             params.keyCompressionStrategy = .unspecified
+            params.encodingEntrySize = pirParameter.encodingEntrySize
         }
     }
 }


### PR DESCRIPTION
We didn't save the `encodingEntrySize` entry when converting to proto. Preventing the server from adopting this feature.