### PR TITLE
Dynamic multi-threading with maxConcurrentTasks

### DIFF
--- a/Benchmarks/PrivateInformationRetrievalBenchmark/PirBenchmark.swift
+++ b/Benchmarks/PrivateInformationRetrievalBenchmark/PirBenchmark.swift
@@ -33,4 +33,15 @@ nonisolated(unsafe) let benchmarks: () -> Void = {
     keywordPirBenchmark(PirUtil<Bfv<UInt32>>.self, callOptions: .singleThreaded)()
     keywordPirBenchmark(PirUtil<Bfv<UInt64>>.self, callOptions: .multiThreaded)()
     keywordPirBenchmark(PirUtil<Bfv<UInt64>>.self, callOptions: .singleThreaded)()
+
+    // Keyword PIR benchmark with 8K entries of 8KB each.
+    // swiftlint:disable:next force_try
+    let largeEntryConfig = try! PirBenchmarkConfig<UInt32>(
+        databaseConfig: .init(entryCount: 8000, entrySizeInBytes: 8000))
+    keywordPirBenchmark(PirUtil<Bfv<UInt32>>.self,
+                        config: largeEntryConfig,
+                        callOptions: .multiThreaded)()
+    keywordPirBenchmark(PirUtil<Bfv<UInt32>>.self,
+                        config: largeEntryConfig,
+                        callOptions: .singleThreaded)()
 }

--- a/Sources/HomomorphicEncryption/Bfv/Bfv.swift
+++ b/Sources/HomomorphicEncryption/Bfv/Bfv.swift
@@ -505,6 +505,152 @@ public enum Bfv<T: ScalarType>: HeScheme {
     }
 
     @inlinable
+    public static func innerProduct(
+        _ lhs: some Collection<CanonicalCiphertext>,
+        _ rhs: some Collection<CanonicalCiphertext>,
+        maxConcurrentTasks: Int) async throws -> CanonicalCiphertext
+    {
+        guard maxConcurrentTasks > 1 else {
+            return try innerProduct(lhs, rhs)
+        }
+
+        @Sendable
+        func lazyMultiply(
+            _ lhs: CanonicalCiphertext,
+            _ rhs: CanonicalCiphertext,
+            to accumulator: inout [Array2d<T.DoubleWidth>]) throws
+        {
+            try validateInnerProductInput(lhs, rhs)
+            let lhsPolys = try computeBehzPolys(ciphertext: lhs)
+            let rhsPolys = try computeBehzPolys(ciphertext: rhs)
+            PolyRq.addingLazyProduct(lhsPolys[0], rhsPolys[0], to: &accumulator[0])
+            PolyRq.addingLazyProduct(lhsPolys[0], rhsPolys[1], to: &accumulator[1])
+            PolyRq.addingLazyProduct(lhsPolys[1], rhsPolys[0], to: &accumulator[1])
+            PolyRq.addingLazyProduct(lhsPolys[1], rhsPolys[1], to: &accumulator[2])
+        }
+
+        let firstCiphertext = lhs[lhs.startIndex]
+        let rnsTool = firstCiphertext.context.getRnsTool(moduliCount: firstCiphertext.moduli.count)
+        let moduliCount = rnsTool.qBskContext.moduli.count
+        let poly = firstCiphertext.polys[0]
+        let maxProductCount = rnsTool.qBskContext.maxLazyProductAccumulationCount() / 2
+        let polyContext = rnsTool.qBskContext
+
+        let pairs = Array(zip(lhs, rhs))
+        let chunkCount = min(maxConcurrentTasks, Util.activeProcessorCount)
+        let chunks = pairs.evenlyChunked(in: chunkCount)
+
+        let partials = try await chunks.concurrentMap(ordered: false) { chunk in
+            var accumulator = Array(
+                repeating: Array2d(
+                    data: Array(repeating: T.DoubleWidth(0), count: moduliCount * poly.degree),
+                    rowCount: moduliCount, columnCount: poly.degree),
+                count: 3)
+            var reduceCount = 0
+            for (lhsCipher, rhsCipher) in chunk {
+                try lazyMultiply(lhsCipher, rhsCipher, to: &accumulator)
+                reduceCount += 1
+                if reduceCount >= maxProductCount {
+                    reduceCount = 0
+                    reduceInPlace(accumulator: &accumulator, polyContext: polyContext)
+                }
+            }
+            reduceInPlace(accumulator: &accumulator, polyContext: polyContext)
+            return accumulator
+        }
+
+        var merged = partials[0]
+        for partial in partials.dropFirst() {
+            for polyIndex in merged.indices {
+                for i in merged[polyIndex].data.indices {
+                    #if DEBUG
+                    let (result, didOverflow) = merged[polyIndex].data[i]
+                        .addingReportingOverflow(partial[polyIndex].data[i])
+                    assert(!didOverflow, "Overflow in polynomial addition at polyIndex \(polyIndex), index \(i)")
+                    merged[polyIndex].data[i] = result
+                    #else
+                    merged[polyIndex].data[i] &+= partial[polyIndex].data[i]
+                    #endif
+                }
+            }
+        }
+
+        var sum = try EvalCiphertext(
+            context: firstCiphertext.context,
+            polys: Array(repeating: .zero(context: rnsTool.qBskContext), count: 3),
+            correctionFactor: 1)
+        reduceToCiphertext(accumulator: merged, result: &sum)
+        return try dropExtendedBase(from: sum)
+    }
+
+    @inlinable
+    public static func innerProduct(ciphertexts: some Collection<EvalCiphertext>,
+                                    plaintexts: some Collection<EvalPlaintext?>,
+                                    maxConcurrentTasks: Int) async throws -> EvalCiphertext
+    {
+        guard maxConcurrentTasks > 1 else {
+            return try innerProduct(ciphertexts: ciphertexts, plaintexts: plaintexts)
+        }
+
+        precondition(plaintexts.count == ciphertexts.count)
+        guard var result = ciphertexts.first else {
+            preconditionFailure("Empty ciphertexts")
+        }
+        precondition(ciphertexts.allSatisfy { $0.polys.count == result.polys.count },
+                     "All ciphertexts must have the same polynomial count")
+        let poly = result.polys[0]
+        let maxProductCount = poly.context.maxLazyProductAccumulationCount()
+        let polyContext = result.polyContext()
+        let polyCount = result.polys.count
+        let dataCount = poly.data.count
+        let moduliCount = poly.moduli.count
+        let degree = poly.degree
+
+        let pairs = Array(zip(ciphertexts, plaintexts))
+        let chunkCount = min(maxConcurrentTasks, Util.activeProcessorCount)
+        let chunks = pairs.evenlyChunked(in: chunkCount)
+
+        let partials = try await chunks.concurrentMap(ordered: false) { chunk in
+            var accumulator = Array(
+                repeating: Array2d(
+                    data: Array(repeating: T.DoubleWidth(0), count: dataCount),
+                    rowCount: moduliCount, columnCount: degree),
+                count: polyCount)
+            var reduceCount = 0
+            for (ciphertext, plaintext) in chunk {
+                guard let plaintext else { continue }
+                try lazyMultiply(ciphertext: ciphertext, plaintext: plaintext, to: &accumulator)
+                reduceCount += 1
+                if reduceCount >= maxProductCount {
+                    reduceCount = 0
+                    reduceInPlace(accumulator: &accumulator, polyContext: polyContext)
+                }
+            }
+            reduceInPlace(accumulator: &accumulator, polyContext: polyContext)
+            return accumulator
+        }
+
+        var merged = partials[0]
+        for partial in partials.dropFirst() {
+            for polyIndex in merged.indices {
+                for i in merged[polyIndex].data.indices {
+                    #if DEBUG
+                    let (result, didOverflow) = merged[polyIndex].data[i]
+                        .addingReportingOverflow(partial[polyIndex].data[i])
+                    assert(!didOverflow, "Overflow in polynomial addition at polyIndex \(polyIndex), index \(i)")
+                    merged[polyIndex].data[i] = result
+                    #else
+                    merged[polyIndex].data[i] &+= partial[polyIndex].data[i]
+                    #endif
+                }
+            }
+        }
+
+        reduceToCiphertext(accumulator: merged, result: &result)
+        return result
+    }
+
+    @inlinable
     public static func forwardNtt(_ ciphertext: inout CoeffCiphertext) throws -> EvalCiphertext {
         let polys = try ciphertext.polys.map { try $0.forwardNtt() }
         return try Ciphertext<Bfv<T>, Eval>(context: ciphertext.context,

--- a/Sources/HomomorphicEncryption/HeScheme.swift
+++ b/Sources/HomomorphicEncryption/HeScheme.swift
@@ -784,6 +784,47 @@ public protocol HeScheme: Sendable {
     static func innerProductAsync(ciphertexts: some Collection<EvalCiphertext>,
                                   plaintexts: some Collection<EvalPlaintext?>) async throws -> EvalCiphertext
 
+    /// Computes an inner product between two collections of ciphertexts with a concurrency budget.
+    ///
+    /// When `maxConcurrentTasks > 1`, the computation may be parallelized.
+    /// - Parameters:
+    ///   - lhs: Left-hand-side ciphertexts. Must not be empty.
+    ///   - rhs: Right-hand-side ciphertexts. Must have `count` matching `lhs.count`.
+    ///   - maxConcurrentTasks: Maximum number of concurrent tasks to use for the computation.
+    /// - Returns: A ciphertext encrypting the inner product.
+    /// - Throws: Error upon failure to compute inner product.
+    static func innerProduct(
+        _ lhs: some Collection<CanonicalCiphertext>,
+        _ rhs: some Collection<CanonicalCiphertext>,
+        maxConcurrentTasks: Int) async throws -> CanonicalCiphertext
+
+    /// Computes an inner product between ciphertexts and plaintexts with a concurrency budget.
+    ///
+    /// When `maxConcurrentTasks > 1`, the computation may be parallelized.
+    /// - Parameters:
+    ///   - ciphertexts: Ciphertexts. Must not be empty.
+    ///   - plaintexts: Plaintexts. Must not be empty and have `count` matching `ciphertexts.count`.
+    ///   - maxConcurrentTasks: Maximum number of concurrent tasks to use for the computation.
+    /// - Returns: A ciphertext encrypting the inner product.
+    /// - Throws: Error upon failure to compute inner product.
+    static func innerProduct(ciphertexts: some Collection<EvalCiphertext>,
+                             plaintexts: some Collection<EvalPlaintext>,
+                             maxConcurrentTasks: Int) async throws -> EvalCiphertext
+
+    /// Computes an inner product between ciphertexts and optional plaintexts with a concurrency budget.
+    ///
+    /// When `maxConcurrentTasks > 1`, the computation may be parallelized.
+    /// `nil` plaintexts indicate zero plaintexts which can be ignored in the computation.
+    /// - Parameters:
+    ///   - ciphertexts: Ciphertexts. Must not be empty.
+    ///   - plaintexts: Plaintexts. Must not be empty and have `count` matching `ciphertexts.count`.
+    ///   - maxConcurrentTasks: Maximum number of concurrent tasks to use for the computation.
+    /// - Returns: A ciphertext encrypting the inner product.
+    /// - Throws: Error upon failure to compute inner product.
+    static func innerProduct(ciphertexts: some Collection<EvalCiphertext>,
+                             plaintexts: some Collection<EvalPlaintext?>,
+                             maxConcurrentTasks: Int) async throws -> EvalCiphertext
+
     /// In-place ciphertext multiplication: `ciphertext *= ciphertext`.
     ///
     /// - Parameters:

--- a/Sources/HomomorphicEncryption/HeSchemeAsync.swift
+++ b/Sources/HomomorphicEncryption/HeSchemeAsync.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2025-2026 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -138,6 +138,43 @@ extension HeScheme {
                                          plaintexts: some Collection<EvalPlaintext?>) async throws -> EvalCiphertext
     {
         try innerProduct(ciphertexts: ciphertexts, plaintexts: plaintexts)
+    }
+
+    @inlinable
+    public static func innerProduct(
+        _ lhs: some Collection<CanonicalCiphertext>,
+        _ rhs: some Collection<CanonicalCiphertext>,
+        maxConcurrentTasks: Int) async throws -> CanonicalCiphertext
+    {
+        if maxConcurrentTasks > 1 {
+            try await innerProductAsync(lhs, rhs)
+        } else {
+            try innerProduct(lhs, rhs)
+        }
+    }
+
+    @inlinable
+    public static func innerProduct(ciphertexts: some Collection<EvalCiphertext>,
+                                    plaintexts: some Collection<EvalPlaintext>,
+                                    maxConcurrentTasks: Int) async throws -> EvalCiphertext
+    {
+        if maxConcurrentTasks > 1 {
+            try await innerProductAsync(ciphertexts: ciphertexts, plaintexts: plaintexts)
+        } else {
+            try innerProduct(ciphertexts: ciphertexts, plaintexts: plaintexts)
+        }
+    }
+
+    @inlinable
+    public static func innerProduct(ciphertexts: some Collection<EvalCiphertext>,
+                                    plaintexts: some Collection<EvalPlaintext?>,
+                                    maxConcurrentTasks: Int) async throws -> EvalCiphertext
+    {
+        if maxConcurrentTasks > 1 {
+            try await innerProductAsync(ciphertexts: ciphertexts, plaintexts: plaintexts)
+        } else {
+            try innerProduct(ciphertexts: ciphertexts, plaintexts: plaintexts)
+        }
     }
 
     @inlinable

--- a/Sources/PIRProcessDatabase/main.swift
+++ b/Sources/PIRProcessDatabase/main.swift
@@ -262,12 +262,9 @@ struct Arguments: Codable, Equatable, Hashable {
         let maxSerializedBucketSize = try cuckooTableArguments.maxSerializedBucketSize ?? {
             let bytesPerPlaintext = try EncryptionParameters<Scheme.Scalar>(from:
                 rlweParameters).bytesPerPlaintext
-            let singleBucketSize = HashBucket.serializedSize(singleValueSize: maxValueSize)
-            return if singleBucketSize >= bytesPerPlaintext / 2 {
-                singleBucketSize.nextMultiple(of: bytesPerPlaintext, variableTime: true)
-            } else {
-                bytesPerPlaintext / 2
-            }
+            return CuckooTableConfig.defaultMaxSerializedBucketSize(
+                maxValueSize: maxValueSize,
+                bytesPerPlaintext: bytesPerPlaintext)
         }()
         guard maxSerializedBucketSize >= HashBucket.serializedSize(singleValueSize: maxValueSize) else {
             let requiredSize = HashBucket.serializedSize(singleValueSize: maxValueSize)

--- a/Sources/PrivateInformationRetrieval/IndexPir/PirUtil.swift
+++ b/Sources/PrivateInformationRetrieval/IndexPir/PirUtil.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+public import Algorithms
 public import AsyncAlgorithms
 public import DequeModule
 public import HomomorphicEncryption
@@ -278,7 +279,7 @@ extension PirUtilProtocol {
                 logStep: logStep + 1,
                 expectedHeight: expectedHeight,
                 using: evaluationKey,
-                callOptions: callOptions)
+                callOptions: callOptions.divided(among: 2))
         }
         let taskRight: @Sendable () async throws -> [CanonicalCiphertext] = {
             try await expandCiphertext(
@@ -287,7 +288,7 @@ extension PirUtilProtocol {
                 logStep: logStep + 1,
                 expectedHeight: expectedHeight,
                 using: evaluationKey,
-                callOptions: callOptions)
+                callOptions: callOptions.divided(among: 2))
         }
         if callOptions.multiThreading {
             async let asyncFirstHalf = taskLeft()
@@ -332,16 +333,21 @@ extension PirUtilProtocol {
         }
         let transform: @Sendable (Int) async throws -> [CanonicalCiphertext] = { [ciphertexts] ciphertextIndex in
             let outputToGenerate = lengths[ciphertextIndex]
+            let childOptions = callOptions.divided(among: min(callOptions.maxConcurrentTasks, ciphertexts.count))
             return try await expandCiphertext(
                 ciphertexts[ciphertextIndex],
                 outputCount: outputToGenerate,
                 logStep: 1,
                 expectedHeight: outputToGenerate.ceilLog2,
                 using: evaluationKey,
-                callOptions: callOptions)
+                callOptions: childOptions)
         }
-        let expanded: [[CanonicalCiphertext]] = if callOptions.multiThreading {
-            try await .init((0..<ciphertexts.count).concurrentMap(transform))
+        let groupCount = max(1, min(callOptions.maxConcurrentTasks, ciphertexts.count))
+        let expanded: [[CanonicalCiphertext]] = if groupCount > 1 {
+            try await .init(Array(0..<ciphertexts.count).evenlyChunked(in: groupCount)
+                .concurrentMap { batch in
+                    try await [[CanonicalCiphertext]](batch.async.map { try await transform($0) }).flatMap(\.self)
+                })
         } else {
             try await .init((0..<ciphertexts.count).async.map(transform))
         }
@@ -415,22 +421,25 @@ extension PirUtilProtocol {
         let databaseColumnsCount = perChunkPlaintextCount / parameter.dimensions[0]
         precondition(databaseColumnsCount == 1 || databaseColumnsCount == expandedRemainingQuery.count)
 
+        let columnGroupCount = max(1, min(callOptions.maxConcurrentTasks, databaseColumnsCount))
+        let columnChildOptions = callOptions.divided(among: columnGroupCount)
+
         let computePtCtInnerProduct: @Sendable (Int) async throws -> Scheme.CanonicalCiphertext = { columnIndex in
             let startIndex = dataChunk.startIndex + expandedDim0Query.count * columnIndex
             let endIndex = min(startIndex + expandedDim0Query.count, dataChunk.endIndex)
             let plaintexts = dataChunk[startIndex..<endIndex]
-            if callOptions.multiThreading {
-                return try await Scheme.innerProductAsync(ciphertexts: expandedDim0Query,
-                                                          plaintexts: plaintexts).convertToCanonicalFormat()
-            }
-            return try await Scheme.innerProduct(ciphertexts: expandedDim0Query, plaintexts: plaintexts)
+            return try await Scheme.innerProduct(ciphertexts: expandedDim0Query,
+                                                 plaintexts: plaintexts,
+                                                 maxConcurrentTasks: columnChildOptions.maxConcurrentTasks)
                 .convertToCanonicalFormat()
         }
 
-        var intermediateResults: [Ciphertext<Scheme, Scheme.CanonicalCiphertextFormat>] = if callOptions
-            .multiThreading
-        {
-            try await (0..<databaseColumnsCount).concurrentMap(computePtCtInnerProduct)
+        var intermediateResults: [Ciphertext<Scheme, Scheme.CanonicalCiphertextFormat>] = if columnGroupCount > 1 {
+            try await Array(0..<databaseColumnsCount).evenlyChunked(in: columnGroupCount)
+                .concurrentMap { batch in
+                    try await [Ciphertext<Scheme, Scheme.CanonicalCiphertextFormat>](batch.async
+                        .map { try await computePtCtInnerProduct($0) })
+                }.flatMap(\.self)
         } else {
             try await .init((0..<databaseColumnsCount).async.map(computePtCtInnerProduct))
         }
@@ -439,11 +448,8 @@ extension PirUtilProtocol {
             .CanonicalCiphertext = { startIndex, currentIndex, dimensionSize, currentResults in
                 let vector0 = expandedRemainingQuery[currentIndex..<currentIndex + dimensionSize]
                 let vector1 = currentResults[startIndex..<startIndex + dimensionSize]
-                var product: Scheme.CanonicalCiphertext = if callOptions.multiThreading {
-                    try await Scheme.innerProductAsync(vector0, vector1)
-                } else {
-                    try Scheme.innerProduct(vector0, vector1)
-                }
+                var product = try await Scheme.innerProduct(vector0, vector1,
+                                                            maxConcurrentTasks: columnChildOptions.maxConcurrentTasks)
                 try await product.relinearize(using: evaluationKey)
                 return product
             }
@@ -451,12 +457,18 @@ extension PirUtilProtocol {
         for await dimensionSize in parameter.dimensions.dropFirst().async {
             let currentIndex = queryStartingIndex
             let lastResult = intermediateResults
-            if callOptions.multiThreading {
+            let dimItemCount = intermediateResults.count / dimensionSize
+            let dimGroupCount = max(1, min(callOptions.maxConcurrentTasks, dimItemCount))
+            if dimGroupCount > 1 {
                 intermediateResults = try await Array(stride(
                     from: 0,
                     to: intermediateResults.count,
-                    by: dimensionSize))
-                    .concurrentMap { try await computeCtCtInnerProduct($0, currentIndex, dimensionSize, lastResult) }
+                    by: dimensionSize)).evenlyChunked(in: dimGroupCount)
+                    .concurrentMap { batch in
+                        try await [Ciphertext<Scheme, Scheme.CanonicalCiphertextFormat>](batch.async.map { startIndex in
+                            try await computeCtCtInnerProduct(startIndex, currentIndex, dimensionSize, lastResult)
+                        })
+                    }.flatMap(\.self)
             } else {
                 intermediateResults = try await .init(stride(
                     from: 0,
@@ -498,21 +510,31 @@ extension PirUtilProtocol {
             -> [[Ciphertext<Scheme, Coeff>]]
         {
             var enumerated = ciphertextForEachQuery.enumerated()
+            let queryCount = ciphertextForEachQuery.count
+            let queryGroupCount = max(1, min(callOptions.maxConcurrentTasks, queryCount))
+            let queryChildOptions = callOptions.divided(among: queryGroupCount)
+
             let computeResponseChunk: @Sendable ((Int, Deque<CanonicalCiphertext>)) async throws
                 -> [Ciphertext<Scheme, Coeff>] = { enumerated in
                     var (queryIndex, queryCiphertexts) = enumerated
                     let database = databases[databases.count == 1 ? 0 : queryIndex]
-                    let firstDimensionQueries: [Ciphertext<Scheme, Eval>] = if callOptions.multiThreading {
-                        try await queryCiphertexts[0..<parameter.dimensions[0]]
-                            .concurrentMap { ciphertext in
-                                try ciphertext.convertToEvalFormat()
-                            }
+                    let dim0Count = parameter.dimensions[0]
+                    let dim0GroupCount = max(1, min(queryChildOptions.maxConcurrentTasks, dim0Count))
+                    let firstDimensionQueries: [Ciphertext<Scheme, Eval>] = if dim0GroupCount > 1 {
+                        try await Array(queryCiphertexts[0..<dim0Count])
+                            .evenlyChunked(in: dim0GroupCount)
+                            .concurrentMap { batch in
+                                try batch.map { try $0.convertToEvalFormat() }
+                            }.flatMap(\.self)
                     } else {
-                        try await .init(queryCiphertexts[0..<parameter.dimensions[0]].async
+                        try await .init(queryCiphertexts[0..<dim0Count].async
                             .map { try $0.convertToEvalFormat() })
                     }
                     queryCiphertexts.removeFirst(parameter.dimensions[0])
                     let perChunkPlaintextCount = database.count / chunkCount
+                    let chunkItemCount = database.count / perChunkPlaintextCount
+                    let chunkGroupCount = max(1, min(queryChildOptions.maxConcurrentTasks, chunkItemCount))
+                    let chunkChildOptions = queryChildOptions.divided(among: chunkGroupCount)
                     let computeRemainingDimensions: @Sendable (Int) async throws -> Ciphertext<Scheme, Coeff> =
                         { [queryCiphertexts, firstDimensionQueries] startIndex in
                             try await Self.computeResponseForOneChunk(
@@ -522,16 +544,20 @@ extension PirUtilProtocol {
                                     .plaintexts[startIndex..<startIndex + perChunkPlaintextCount],
                                 using: evaluationKey,
                                 parameter: parameter,
-                                callOptions: callOptions)
+                                callOptions: chunkChildOptions)
                         }
-                    if callOptions.multiThreading {
+                    if chunkGroupCount > 1 {
                         return try await Array(stride(from: 0, to: database.count, by: perChunkPlaintextCount))
-                            .concurrentMap(computeRemainingDimensions)
+                            .evenlyChunked(in: chunkGroupCount)
+                            .concurrentMap { batch in
+                                try await [Ciphertext<Scheme, Coeff>](batch.async
+                                    .map { try await computeRemainingDimensions($0) })
+                            }.flatMap(\.self)
                     }
                     return try await .init(stride(from: 0, to: database.count, by: perChunkPlaintextCount).async
                         .map(computeRemainingDimensions))
                 }
-            if callOptions.multiThreading {
+            if queryGroupCount > 1 {
                 return try await enumerated.concurrentConsumingMap(computeResponseChunk)
             }
             return try await .init(enumerated.async.map(computeResponseChunk))

--- a/Sources/PrivateInformationRetrieval/KeywordPir/CuckooTable.swift
+++ b/Sources/PrivateInformationRetrieval/KeywordPir/CuckooTable.swift
@@ -98,6 +98,25 @@ public struct CuckooTableConfig: Hashable, Codable, Sendable {
             bucketCount: .allowExpansion(expansionFactor: 1.1, targetLoadFactor: 0.9))
     }
 
+    /// Computes a default `maxSerializedBucketSize` for keyword PIR.
+    ///
+    /// When the serialized size of a single-entry bucket exceeds half of `bytesPerPlaintext`,
+    /// rounds up to the next multiple of `bytesPerPlaintext`. Otherwise uses `bytesPerPlaintext / 2`.
+    /// - Parameters:
+    ///   - maxValueSize: Maximum value size in bytes across all entries.
+    ///   - bytesPerPlaintext: Bytes per plaintext from the encryption parameters.
+    /// - Returns: A suitable `maxSerializedBucketSize`.
+    package static func defaultMaxSerializedBucketSize(
+        maxValueSize: Int,
+        bytesPerPlaintext: Int) -> Int
+    {
+        let singleBucketSize = HashBucket.serializedSize(singleValueSize: maxValueSize)
+        if singleBucketSize >= bytesPerPlaintext / 2 {
+            return singleBucketSize.nextMultiple(of: bytesPerPlaintext, variableTime: true)
+        }
+        return bytesPerPlaintext / 2
+    }
+
     /// Converts the configuration into one with a fixed bucket count.
     /// - Parameters:
     ///   - maxSerializedBucketSize: Maximum number of evictions when inserting a new entry.

--- a/Sources/PrivateInformationRetrieval/Util/Util.swift
+++ b/Sources/PrivateInformationRetrieval/Util/Util.swift
@@ -26,7 +26,7 @@ extension [UInt8] {
 
 /// Runtime options to specify configs. E.g. multi-threading preference.
 public enum CallOptions: Equatable, Sendable {
-    case multiThreaded
+    case multiThreaded(maxConcurrentTasks: Int)
     case singleThreaded
 }
 
@@ -34,7 +34,33 @@ extension CallOptions {
     /// Default call options
     public static let `default` = CallOptions.singleThreaded
 
+    /// Convenience: `.multiThreaded` without explicit `maxConcurrentTasks` uses all processors.
+    public static var multiThreaded: CallOptions {
+        .multiThreaded(maxConcurrentTasks: ProcessInfo.processInfo.activeProcessorCount)
+    }
+
     @usableFromInline var multiThreading: Bool {
-        self != .singleThreaded
+        if case .singleThreaded = self {
+            return false
+        }
+        return true
+    }
+
+    /// The maximum number of concurrent tasks for this call option.
+    @usableFromInline var maxConcurrentTasks: Int {
+        switch self {
+        case let .multiThreaded(maxConcurrentTasks): maxConcurrentTasks
+        case .singleThreaded: 1
+        }
+    }
+
+    /// Divide `maxConcurrentTasks` among `groupCount` child tasks.
+    @usableFromInline
+    func divided(among groupCount: Int) -> CallOptions {
+        let childMaxConcurrentTasks = max(1, maxConcurrentTasks / max(1, groupCount))
+        if childMaxConcurrentTasks <= 1 {
+            return .singleThreaded
+        }
+        return .multiThreaded(maxConcurrentTasks: childMaxConcurrentTasks)
     }
 }

--- a/Sources/_BenchmarkUtilities/PirBenchmarkUtilities.swift
+++ b/Sources/_BenchmarkUtilities/PirBenchmarkUtilities.swift
@@ -72,9 +72,17 @@ func formatKeyCompression(_ compression: PirKeyCompressionStrategy) -> String {
     }
 }
 
-/// Returns a short threading label (`allThread` or `1Thread`).
+/// Returns a short threading label (e.g. `Threads:10`, `Threads:1`, `Threads:all`).
 func formatCallOptions(_ options: CallOptions) -> String {
-    options == .multiThreaded ? "allThread" : "1Thread"
+    switch options {
+    case let .multiThreaded(maxConcurrentTasks)
+        where maxConcurrentTasks >= ProcessInfo.processInfo.activeProcessorCount:
+        "Threads:all"
+    case let .multiThreaded(maxConcurrentTasks):
+        "Threads:\(maxConcurrentTasks)"
+    case .singleThreaded:
+        "Threads:1"
+    }
 }
 
 /// Configuration for a PIR database.
@@ -131,8 +139,11 @@ public struct PirBenchmarkConfig<Scalar: ScalarType> {
             self.keywordPirConfig = keywordPirConfig
         } else {
             let encryptionParams = try EncryptionParameters<Scalar>(from: encryptionConfig)
+            let maxSerializedBucketSize = CuckooTableConfig.defaultMaxSerializedBucketSize(
+                maxValueSize: databaseConfig.entrySizeInBytes,
+                bytesPerPlaintext: encryptionParams.bytesPerPlaintext)
             let cuckooTableConfig = CuckooTableConfig
-                .defaultKeywordPir(maxSerializedBucketSize: encryptionParams.bytesPerPlaintext)
+                .defaultKeywordPir(maxSerializedBucketSize: maxSerializedBucketSize)
             self.keywordPirConfig = try KeywordPirConfig(dimensionCount: 2, cuckooTableConfig: cuckooTableConfig,
                                                          unevenDimensions: true,
                                                          keyCompression: .hybridCompression)


### PR DESCRIPTION
- Replace boolean CallOptions.multiThreaded with CallOptions.multiThreaded(maxConcurrentTasks:) to allow fine-grained control over concurrency
- Add divided(among:) to split task budget among child groups
- Add parallel innerProduct overloads (ct-ct and ct-pt) to HeScheme, with optimized Bfv implementations using chunked lazy accumulation
- Refactor PirUtil to use evenlyChunked batching with group-count-based concurrency instead of all-or-nothing multiThreading boolean
- Extract CuckooTableConfig.defaultMaxSerializedBucketSize helper
- Add large-entry (8K x 8KB) keyword PIR benchmark